### PR TITLE
server: OpenAI API and llama.cpp Web UI compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/llama.cpp"]
+	path = third_party/llama.cpp
+	url = https://github.com/ggml-org/llama.cpp

--- a/HACKING.md
+++ b/HACKING.md
@@ -74,6 +74,21 @@ Open two terminal windows:
 
 > **Tip:** Refer to the `justfile` for additional common commands and automation. For troubleshooting, see [CONTRIBUTING.md](CONTRIBUTING.md) and open an issue if you need help.
 
+### Llama.cpp Web UI (optional)
+
+To use the upstream [llama.cpp](https://github.com/ggml-org/llama.cpp) SvelteKit chat UI against the Tiles Python server:
+
+1. Keep **their** repository read-only from Tiles’ perspective: clone or add a **git submodule** (e.g. at `third_party/llama.cpp`), then `git pull` or bump the submodule revision when you want their updates. Do not push Tiles-only commits to `ggml-org/llama.cpp`.
+2. Start Tiles (`just serve`, default `http://127.0.0.1:6969`).
+3. From the Tiles repo root, run `scripts/phase2_llamacpp_webui.sh`. It resolves `llama.cpp` in this order: `LLAMA_CPP_ROOT`, then `third_party/llama.cpp`, then a sibling `../llama.cpp` clone. It patches `tools/server/webui/vite.config.ts` to proxy API routes to the Tiles backend when needed.
+
+   Optional submodule (pinned revision in your Tiles fork/branch):
+
+   ```sh
+   git submodule add https://github.com/ggml-org/llama.cpp third_party/llama.cpp
+   git submodule update --init --recursive
+   ```
+
 ### Building Tiles installer (Development)
 
 Install [venvstacks](https://github.com/lmstudio-ai/venvstacks?tab=readme-ov-file#installing) for portable py runtime

--- a/justfile
+++ b/justfile
@@ -15,6 +15,14 @@ serve:
     server/.venv/bin/python3 -m server.main
     # uv run --project server python -m server.main
 
+# Python server (OpenAI compat API tests; requires uv sync in server/)
+test-server:
+    uv run --project server pytest server/tests/ -v
+
+# llama.cpp SvelteKit UI (clone under ../llama.cpp by default); proxies to Tiles :6969
+webui-llamacpp:
+    bash scripts/phase2_llamacpp_webui.sh
+
 bundle:
     ./scripts/bundler.sh
 

--- a/scripts/phase2_llamacpp_webui.sh
+++ b/scripts/phase2_llamacpp_webui.sh
@@ -31,9 +31,16 @@ BACKEND="${TILES_BACKEND:-http://127.0.0.1:6969}"
 WEBUI="$LLAMA_CPP/tools/server/webui"
 VITE_CFG="$WEBUI/vite.config.ts"
 
+echo "Using llama.cpp at: $LLAMA_CPP"
+
 if [ ! -d "$LLAMA_CPP" ]; then
-  echo "Cloning llama.cpp -> $LLAMA_CPP"
-  git clone --depth 1 https://github.com/ggml-org/llama.cpp "$LLAMA_CPP"
+	if [ "$LLAMA_CPP" = "$ROOT/third_party/llama.cpp" ]; then
+		echo "third_party/llama.cpp is missing. Initialize the submodule (do not clone on top of it):"
+		echo "  git submodule update --init --recursive"
+		exit 1
+	fi
+	echo "Cloning llama.cpp -> $LLAMA_CPP"
+	git clone --depth 1 https://github.com/ggml-org/llama.cpp "$LLAMA_CPP"
 fi
 
 if [ ! -f "$VITE_CFG" ]; then
@@ -42,9 +49,10 @@ if [ ! -f "$VITE_CFG" ]; then
 fi
 
 if ! grep -qF "$BACKEND" "$VITE_CFG" 2>/dev/null; then
-  echo "Patching $VITE_CFG to proxy API routes to $BACKEND"
-  cp "$VITE_CFG" "${VITE_CFG}.tiles.bak"
-  perl -pi -e "s|http://localhost:8080|${BACKEND}|g" "$VITE_CFG"
+	echo "Patching $VITE_CFG so all dev-server proxy routes point to $BACKEND"
+	cp "$VITE_CFG" "${VITE_CFG}.tiles.bak"
+	# Upstream defaults vary; replace every occurrence in the file (proxy table uses the same base URL per line).
+	perl -pi -e "s|http://localhost:8080|${BACKEND}|g; s|http://127\\.0\\.0\\.1:8080|${BACKEND}|g" "$VITE_CFG"
 fi
 
 echo "Backend proxy: $BACKEND (run Tiles with just serve). Load model via POST /start, session file, TILES_BOOTSTRAP_*, or TILES_MODEL_CACHE_PATH + UI load."

--- a/scripts/phase2_llamacpp_webui.sh
+++ b/scripts/phase2_llamacpp_webui.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Run ggml-org/llama.cpp SvelteKit web UI with the dev proxy pointed at the Tiles server.
+#
+# Prerequisites: Node.js (npm), git. Start Tiles separately (e.g. just serve on :6969).
+#
+# Environment:
+#   LLAMA_CPP_ROOT   Clone path (default: sibling of this repo: ../llama.cpp)
+#   TILES_BACKEND    Proxy target (default: http://127.0.0.1:6969)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LLAMA_CPP="${LLAMA_CPP_ROOT:-$ROOT/../llama.cpp}"
+BACKEND="${TILES_BACKEND:-http://127.0.0.1:6969}"
+WEBUI="$LLAMA_CPP/tools/server/webui"
+VITE_CFG="$WEBUI/vite.config.ts"
+
+if [ ! -d "$LLAMA_CPP" ]; then
+  echo "Cloning llama.cpp -> $LLAMA_CPP"
+  git clone --depth 1 https://github.com/ggml-org/llama.cpp "$LLAMA_CPP"
+fi
+
+if [ ! -f "$VITE_CFG" ]; then
+  echo "Expected file missing: $VITE_CFG"
+  exit 1
+fi
+
+if ! grep -qF "$BACKEND" "$VITE_CFG" 2>/dev/null; then
+  echo "Patching $VITE_CFG to proxy API routes to $BACKEND"
+  cp "$VITE_CFG" "${VITE_CFG}.tiles.bak"
+  perl -pi -e "s|http://localhost:8080|${BACKEND}|g" "$VITE_CFG"
+fi
+
+echo "Backend proxy: $BACKEND (run Tiles with just serve). Load model via POST /start, session file, TILES_BOOTSTRAP_*, or TILES_MODEL_CACHE_PATH + UI load."
+echo ""
+
+cd "$WEBUI"
+if [ -f package-lock.json ]; then
+  npm ci
+else
+  npm install
+fi
+exec npm run dev

--- a/scripts/phase2_llamacpp_webui.sh
+++ b/scripts/phase2_llamacpp_webui.sh
@@ -1,16 +1,32 @@
 #!/usr/bin/env bash
 # Run ggml-org/llama.cpp SvelteKit web UI with the dev proxy pointed at the Tiles server.
 #
+# Workflow: use upstream llama.cpp only (https://github.com/ggml-org/llama.cpp). Pull or
+# bump a submodule when you want UI updates; do not commit Tiles-specific changes into
+# their tree. This script may patch vite.config.ts locally (see .tiles.bak); re-run after
+# upstream changes that alter the dev proxy block.
+#
 # Prerequisites: Node.js (npm), git. Start Tiles separately (e.g. just serve on :6969).
 #
 # Environment:
-#   LLAMA_CPP_ROOT   Clone path (default: sibling of this repo: ../llama.cpp)
+#   LLAMA_CPP_ROOT   Override tree path (otherwise see resolution below)
 #   TILES_BACKEND    Proxy target (default: http://127.0.0.1:6969)
+#
+# llama.cpp location (first match wins):
+#   1. LLAMA_CPP_ROOT if set
+#   2. third_party/llama.cpp under this repo (e.g. git submodule)
+#   3. ../llama.cpp next to this repo (sibling clone)
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-LLAMA_CPP="${LLAMA_CPP_ROOT:-$ROOT/../llama.cpp}"
+if [ -n "${LLAMA_CPP_ROOT:-}" ]; then
+	LLAMA_CPP="$LLAMA_CPP_ROOT"
+elif [ -d "$ROOT/third_party/llama.cpp" ]; then
+	LLAMA_CPP="$ROOT/third_party/llama.cpp"
+else
+	LLAMA_CPP="$ROOT/../llama.cpp"
+fi
 BACKEND="${TILES_BACKEND:-http://127.0.0.1:6969}"
 WEBUI="$LLAMA_CPP/tools/server/webui"
 VITE_CFG="$WEBUI/vite.config.ts"

--- a/server/api.py
+++ b/server/api.py
@@ -1,23 +1,31 @@
+import asyncio
+import json
 import logging
-import sys
-from typing import Optional
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import Any, Optional
 
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from . import runtime
+from . import session_persist
+from .config import MEMORY_PATH
 from .mem_agent.engine import execute_sandboxed_code
-from .mem_agent.utils import (
-    create_memory_if_not_exists,
-    format_results,
+from .mem_agent.utils import format_results
+from .llamacpp_webui_compat import (
+    openai_model_entry_with_llama_fields,
+    tiles_props_for_webui,
 )
 from .schemas import (
     ChatCompletionRequest,
     ChatMessage,
     ResponsesRequest,
+    RouterModelsLoadBody,
     StartRequest,
-    downloadRequest,
 )
 
 logger = logging.getLogger("app")
@@ -26,9 +34,145 @@ _default_max_tokens: Optional[int] = None  # Use dynamic model-aware limits by d
 _memory_path = ""
 
 _messages: list[ChatMessage] = []
+_loaded_model_id: Optional[str] = None
+_loaded_model_cache_path: Optional[str] = None
+_model_loaded_at: Optional[int] = None
+
+SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
 
 
-app = FastAPI()
+def _apply_loaded_session(
+    model: str,
+    model_cache_path: str,
+    memory_path: str,
+    system_prompt: str,
+) -> None:
+    global _messages, _memory_path, _loaded_model_id, _loaded_model_cache_path, _model_loaded_at
+    runtime.backend.get_or_load_model(model, model_cache_path)
+    _loaded_model_id = model
+    _loaded_model_cache_path = model_cache_path
+    _memory_path = memory_path
+    _messages = [ChatMessage(role="system", content=system_prompt)]
+    _model_loaded_at = int(time.time())
+
+
+def _env_bootstrap_session_data() -> session_persist.SessionData | None:
+    m = os.environ.get("TILES_BOOTSTRAP_MODEL", "").strip()
+    c = os.environ.get("TILES_BOOTSTRAP_MODEL_CACHE_PATH", "").strip()
+    if not m or not c:
+        return None
+    mem = os.environ.get("TILES_BOOTSTRAP_MEMORY_PATH", "").strip() or MEMORY_PATH
+    sysp = os.environ.get("TILES_BOOTSTRAP_SYSTEM_PROMPT", "").strip() or "You are a helpful assistant."
+    return {
+        "model": m,
+        "model_cache_path": c,
+        "memory_path": mem,
+        "system_prompt": sysp,
+    }
+
+
+async def _restore_session_on_startup() -> None:
+    if session_persist.skip_persist():
+        return
+
+    data = session_persist.load()
+    if data:
+        try:
+            await asyncio.to_thread(
+                _apply_loaded_session,
+                data["model"],
+                data["model_cache_path"],
+                data["memory_path"],
+                data["system_prompt"],
+            )
+            logger.info("Restored persisted session: model=%s", data["model"])
+            return
+        except Exception as e:
+            logger.warning("Could not restore persisted session: %s", e)
+
+    boot = _env_bootstrap_session_data()
+    if boot:
+        try:
+            await asyncio.to_thread(
+                _apply_loaded_session,
+                boot["model"],
+                boot["model_cache_path"],
+                boot["memory_path"],
+                boot["system_prompt"],
+            )
+            logger.info("Bootstrap model from env TILES_BOOTSTRAP_*: model=%s", boot["model"])
+            session_persist.save(boot)
+        except Exception as e:
+            logger.warning("Could not bootstrap model from TILES_BOOTSTRAP_*: %s", e)
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    await _restore_session_on_startup()
+    yield
+
+
+app = FastAPI(lifespan=_lifespan)
+
+
+@app.exception_handler(RequestValidationError)
+async def openai_validation_errors(request: Request, exc: RequestValidationError) -> JSONResponse:
+    if request.url.path.startswith("/v1/"):
+        parts = []
+        for e in exc.errors():
+            loc = "/".join(str(x) for x in e.get("loc", ()))
+            parts.append(f"{loc}: {e.get('msg', '')}")
+        msg = "; ".join(parts) if parts else "Invalid request"
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": {
+                    "message": msg,
+                    "type": "invalid_request_error",
+                    "param": None,
+                    "code": None,
+                }
+            },
+        )
+    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+
+
+@app.exception_handler(HTTPException)
+async def openai_http_errors(request: Request, exc: HTTPException) -> JSONResponse:
+    if request.url.path.startswith("/v1/"):
+        detail: Any = exc.detail
+        msg = detail if isinstance(detail, str) else json.dumps(detail)
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "error": {
+                    "message": msg,
+                    "type": "api_error",
+                    "code": None,
+                }
+            },
+        )
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _openai_compat_effective_messages(request: ChatCompletionRequest) -> list[ChatMessage]:
+    """Stateless OpenAI chat: optional session system from /start + client messages."""
+    if _messages and _messages[0].role == "system":
+        return [_messages[0]] + list(request.messages)
+    return list(request.messages)
 
 
 @app.get("/ping")
@@ -36,25 +180,118 @@ async def ping():
     return {"message": "Badda-Bing Badda-Bang"}
 
 
+@app.get("/health")
+@app.get("/v1/health")
+async def health():
+    """Liveness and basic readiness (model slot may be empty)."""
+    return {
+        "status": "ok",
+        "tiles": True,
+        "model_loaded": _loaded_model_id is not None,
+        "model": _loaded_model_id,
+    }
+
+
+@app.post("/models/load")
+async def models_load(body: RouterModelsLoadBody):
+    """Llama Web UI load hook: body is {\"model\": \"<id>\"}; MLX dir from TILES_MODEL_CACHE_PATH."""
+    cache = (
+        os.environ.get("TILES_MODEL_CACHE_PATH", "").strip()
+        or os.environ.get("TILES_BOOTSTRAP_MODEL_CACHE_PATH", "").strip()
+    )
+    if not cache:
+        return {
+            "success": False,
+            "error": "Set TILES_MODEL_CACHE_PATH to the MLX model directory (absolute path), or use POST /start.",
+        }
+    mid = body.model.strip()
+    if not mid:
+        return {"success": False, "error": "Missing model id in JSON body."}
+    sysp = os.environ.get("TILES_BOOTSTRAP_SYSTEM_PROMPT", "").strip() or "You are a helpful assistant."
+    try:
+        _apply_loaded_session(mid, cache, MEMORY_PATH, sysp)
+        session_persist.save(
+            {
+                "model": mid,
+                "model_cache_path": cache,
+                "memory_path": MEMORY_PATH,
+                "system_prompt": sysp,
+            }
+        )
+        return {"success": True}
+    except Exception as e:
+        logger.warning("POST /models/load failed: %s", e)
+        return {"success": False, "error": str(e)}
+
+
+@app.post("/models/unload")
+async def models_unload_stub():
+    return {
+        "success": False,
+        "error": "Tiles does not expose unload; restart the server to release the model.",
+    }
+
+
+@app.get("/props")
+async def server_props():
+    """Llama.cpp web UI expects this (see tools/server/webui PropsService)."""
+    return tiles_props_for_webui(_loaded_model_cache_path)
+
+
+@app.get("/v1/models")
+async def list_models():
+    """OpenAI-compatible model list (models appear after POST /start)."""
+    data: list[dict] = []
+    if _loaded_model_id is not None:
+        data.append(
+            openai_model_entry_with_llama_fields(
+                _loaded_model_id,
+                _model_loaded_at or int(time.time()),
+                model_cache_path=_loaded_model_cache_path,
+            )
+        )
+    return {"object": "list", "data": data}
+
+
 @app.post("/start")
 async def start_model(request: StartRequest):
     """Load the model and start the agent"""
-    global _messages, _runner, _memory_path
-    print(f"CACHE PATH{request.model_cache_path}")
-
-    _messages = [ChatMessage(role="system", content=request.system_prompt)]
-    _memory_path = request.memory_path
-    logger.info(f"{runtime.backend}")
-    runtime.backend.get_or_load_model(request.model, request.model_cache_path)
+    logger.info("%s", runtime.backend)
+    _apply_loaded_session(
+        request.model,
+        request.model_cache_path,
+        request.memory_path,
+        request.system_prompt,
+    )
+    session_persist.save(
+        {
+            "model": request.model,
+            "model_cache_path": request.model_cache_path,
+            "memory_path": request.memory_path,
+            "system_prompt": request.system_prompt,
+        }
+    )
     return {"message": "Model loaded"}
 
 
 @app.post("/v1/chat/completions")
 async def create_chat_completion(request: ChatCompletionRequest):
-    """Create a chat completion."""
+    """Create a chat completion (OpenAI SSE when stream=true; memory-agent when input is set)."""
     global _messages, _memory_path
     try:
-        if request.stream:
+        resolved_model = (request.model or "").strip() or _loaded_model_id
+        if not resolved_model:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "No model loaded: send JSON 'model', or POST /start, or set TILES_BOOTSTRAP_* for auto-load."
+                ),
+            )
+        request = request.model_copy(update={"model": resolved_model})
+
+        memory_path = request.input is not None
+
+        if memory_path:
             result = ({}, "")
             if request.python_code:
                 result = execute_sandboxed_code(
@@ -67,14 +304,28 @@ async def create_chat_completion(request: ChatCompletionRequest):
                 ChatMessage(role="user", content=format_results(result[0], result[1]))
             )
 
-            # Streaming response
-            return StreamingResponse(
-                runtime.backend.generate_chat_stream(_messages, request),
-                media_type="text/plain",
-                headers={"Cache-Control": "no-cache"},
+            if request.stream:
+                return StreamingResponse(
+                    runtime.backend.generate_chat_stream(_messages, request),
+                    media_type="text/event-stream",
+                    headers=dict(SSE_HEADERS),
+                )
+            return JSONResponse(
+                runtime.backend.complete_openai_chat_completion(_messages, request)
             )
+
+        eff = _openai_compat_effective_messages(request)
+        if request.stream:
+            return StreamingResponse(
+                runtime.backend.generate_chat_stream(eff, request),
+                media_type="text/event-stream",
+                headers=dict(SSE_HEADERS),
+            )
+        return JSONResponse(runtime.backend.complete_openai_chat_completion(eff, request))
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @app.post("/v1/responses")
@@ -86,8 +337,8 @@ async def create_chat_response(request: ResponsesRequest):
     if request.stream:
         return StreamingResponse(
             runtime.backend.generate_response_chat_stream(request),
-            media_type="text/plain",
-            headers={"Cache-Control": "no-cache"},
+            media_type="text/event-stream",
+            headers=dict(SSE_HEADERS),
         )
     else:
         return await runtime.backend.generate_response_chat(request)

--- a/server/api.py
+++ b/server/api.py
@@ -45,6 +45,23 @@ SSE_HEADERS = {
 }
 
 
+def _cors_allow_origins() -> list[str]:
+    """Browser CORS is opt-in: TILES_CORS_ORIGINS (comma-separated) or TILES_CORS_ALLOW_ALL=1 (dev only)."""
+    if os.environ.get("TILES_CORS_ALLOW_ALL", "").strip() == "1":
+        return ["*"]
+    raw = os.environ.get("TILES_CORS_ORIGINS", "").strip()
+    if not raw:
+        return []
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
+def _persist_session_best_effort(data: session_persist.SessionData) -> None:
+    try:
+        session_persist.save(data)
+    except OSError as e:
+        logger.warning("Persisting session failed after model load: %s", e)
+
+
 def _apply_loaded_session(
     model: str,
     model_cache_path: str,
@@ -105,7 +122,7 @@ async def _restore_session_on_startup() -> None:
                 boot["system_prompt"],
             )
             logger.info("Bootstrap model from env TILES_BOOTSTRAP_*: model=%s", boot["model"])
-            session_persist.save(boot)
+            _persist_session_best_effort(boot)
         except Exception as e:
             logger.warning("Could not bootstrap model from TILES_BOOTSTRAP_*: %s", e)
 
@@ -159,13 +176,15 @@ async def openai_http_errors(request: Request, exc: HTTPException) -> JSONRespon
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+_cors_origins = _cors_allow_origins()
+if _cors_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_cors_origins,
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 
 def _openai_compat_effective_messages(request: ChatCompletionRequest) -> list[ChatMessage]:
@@ -209,8 +228,8 @@ async def models_load(body: RouterModelsLoadBody):
         return {"success": False, "error": "Missing model id in JSON body."}
     sysp = os.environ.get("TILES_BOOTSTRAP_SYSTEM_PROMPT", "").strip() or "You are a helpful assistant."
     try:
-        _apply_loaded_session(mid, cache, MEMORY_PATH, sysp)
-        session_persist.save(
+        await asyncio.to_thread(_apply_loaded_session, mid, cache, MEMORY_PATH, sysp)
+        _persist_session_best_effort(
             {
                 "model": mid,
                 "model_cache_path": cache,
@@ -257,13 +276,14 @@ async def list_models():
 async def start_model(request: StartRequest):
     """Load the model and start the agent"""
     logger.info("%s", runtime.backend)
-    _apply_loaded_session(
+    await asyncio.to_thread(
+        _apply_loaded_session,
         request.model,
         request.model_cache_path,
         request.memory_path,
         request.system_prompt,
     )
-    session_persist.save(
+    _persist_session_best_effort(
         {
             "model": request.model,
             "model_cache_path": request.model_cache_path,

--- a/server/backend/mlx.py
+++ b/server/backend/mlx.py
@@ -84,6 +84,25 @@ def get_or_load_model(
         return _model_cache[_current_model_path]  # pyright: ignore
 
 
+def _chat_completion_metrics_dict(m: GenerationMetrics) -> dict[str, float | int]:
+    """Tiles CLI reads `metrics` on the final SSE chunk (memory-mode /v1/chat/completions)."""
+    return {
+        "ttft_ms": m.ttft_ms,
+        "total_tokens": m.total_tokens,
+        "tokens_per_second": m.tokens_per_second,
+        "total_latency_s": m.total_latency_s,
+    }
+
+
+def _llama_webui_timings_from_metrics(m: GenerationMetrics) -> dict[str, float | int]:
+    """llama.cpp Web UI reads `timings` for tokens/s in the chat footer."""
+    pred_ms = max(1.0, m.total_latency_s * 1000.0)
+    return {
+        "predicted_n": m.total_tokens,
+        "predicted_ms": pred_ms,
+    }
+
+
 async def generate_chat_stream(
     messages: List[ChatMessage], request: ChatCompletionRequest
 ) -> AsyncGenerator[str, None]:
@@ -176,16 +195,69 @@ async def generate_chat_stream(
         "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
     }
 
-    # Include benchmarking metrics if available
     if metrics:
-        final_response["metrics"] = {
-            "ttft_ms": metrics.ttft_ms,
-            "total_tokens": metrics.total_tokens,
-            "tokens_per_second": metrics.tokens_per_second,
-            "total_latency_s": metrics.total_latency_s,
-        }
+        final_response["metrics"] = _chat_completion_metrics_dict(metrics)
+        final_response["timings"] = _llama_webui_timings_from_metrics(metrics)
     yield f"data: {json.dumps(final_response)}\n\n"
     yield "data: [DONE]\n\n"
+
+
+def complete_openai_chat_completion(
+    messages: List[ChatMessage], request: ChatCompletionRequest
+) -> dict[str, Any]:
+    """Non-streaming OpenAI-shaped chat completion (collects streaming generation)."""
+    runner = get_or_load_model(request.model, None)
+    message_dicts = format_chat_messages_for_runner(messages)
+    prompt = runner._format_conversation(message_dicts, use_chat_template=True)
+    completion_id = f"chatcmpl-{uuid.uuid4()}"
+    created = int(time.time())
+    parts: list[str] = []
+    metrics: GenerationMetrics | None = None
+    try:
+        for token in runner.generate_streaming(
+            prompt=prompt,
+            max_tokens=runner.get_effective_max_tokens(
+                request.max_tokens or _default_max_tokens, interactive=False
+            ),
+            temperature=request.temperature,
+            top_p=request.top_p,
+            repetition_penalty=request.repetition_penalty,
+            use_chat_template=False,
+            use_chat_stop_tokens=False,
+        ):
+            if isinstance(token, GenerationMetrics):
+                metrics = token
+                continue
+            if not isinstance(token, str):
+                continue
+            parts.append(token)
+            if request.stop:
+                stop_sequences = (
+                    request.stop if isinstance(request.stop, list) else [request.stop]
+                )
+                if any(stop in token for stop in stop_sequences):
+                    break
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    text = "".join(parts)
+    out: dict[str, Any] = {
+        "id": completion_id,
+        "object": "chat.completion",
+        "created": created,
+        "model": request.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    if metrics:
+        out["metrics"] = _chat_completion_metrics_dict(metrics)
+        out["timings"] = _llama_webui_timings_from_metrics(metrics)
+    return out
 
 
 def format_chat_messages_for_runner(

--- a/server/llamacpp_webui_compat.py
+++ b/server/llamacpp_webui_compat.py
@@ -1,0 +1,146 @@
+"""
+Minimal responses for ggml-org/llama.cpp tools/server/webui (SvelteKit).
+
+The Web UI expects GET /props (llama-server shape) and enriched /v1/models entries.
+OpenAI-only clients can ignore these fields.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _default_params() -> dict[str, Any]:
+    return {
+        "n_predict": -1,
+        "seed": -1,
+        "temperature": 0.8,
+        "dynatemp_range": 0.0,
+        "dynatemp_exponent": 1.0,
+        "top_k": 40,
+        "top_p": 0.95,
+        "min_p": 0.05,
+        "top_n_sigma": -1.0,
+        "xtc_probability": 0.0,
+        "xtc_threshold": 0.1,
+        "typ_p": 1.0,
+        "repeat_last_n": 64,
+        "repeat_penalty": 1.0,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "dry_multiplier": 0.0,
+        "dry_base": 1.75,
+        "dry_allowed_length": 2,
+        "dry_penalty_last_n": -1,
+        "dry_sequence_breakers": [],
+        "mirostat": 0,
+        "mirostat_tau": 5.0,
+        "mirostat_eta": 0.1,
+        "stop": [],
+        "max_tokens": 8192,
+        "n_keep": 0,
+        "n_discard": 0,
+        "ignore_eos": False,
+        "stream": True,
+        "logit_bias": [],
+        "n_probs": 0,
+        "min_keep": 0,
+        "grammar": "",
+        "grammar_lazy": False,
+        "grammar_triggers": [],
+        "preserved_tokens": [],
+        "chat_format": "Content-only",
+        "reasoning_format": "none",
+        "reasoning_in_content": False,
+        "generation_prompt": "",
+        "samplers": "penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature",
+        "backend_sampling": False,
+        "speculative.n_max": 16,
+        "speculative.n_min": 0,
+        "speculative.p_min": 0.75,
+        "timings_per_token": False,
+        "post_sampling_probs": False,
+        "lora": [],
+    }
+
+
+def _read_n_ctx(model_cache_path: str | None) -> int:
+    if not model_cache_path:
+        return 8192
+    p = Path(model_cache_path) / "config.json"
+    if not p.is_file():
+        return 8192
+    try:
+        with open(p, encoding="utf-8") as f:
+            cfg = json.load(f)
+        for key in (
+            "max_position_embeddings",
+            "n_positions",
+            "context_length",
+            "max_sequence_length",
+        ):
+            v = cfg.get(key)
+            if isinstance(v, int) and v > 0:
+                return min(v, 262144)
+    except (OSError, json.JSONDecodeError, TypeError):
+        pass
+    return 8192
+
+
+def tiles_props_for_webui(
+    model_cache_path: str | None,
+    *,
+    build_info: str = "tiles-python-server",
+) -> dict[str, Any]:
+    """Shape compatible with ApiLlamaCppServerProps in llama.cpp webui."""
+    n_ctx = _read_n_ctx(model_cache_path)
+    path = model_cache_path or ""
+    params = _default_params()
+    return {
+        "default_generation_settings": {
+            "id": 0,
+            "id_task": 0,
+            "n_ctx": n_ctx,
+            "speculative": False,
+            "is_processing": False,
+            "params": params,
+            "prompt": "",
+            "next_token": {
+                "has_next_token": False,
+                "has_new_line": False,
+                "n_remain": 0,
+                "n_decoded": 0,
+                "stopping_word": "",
+            },
+        },
+        "total_slots": 1,
+        "model_path": path,
+        "role": "model",
+        "modalities": {"vision": False, "audio": False},
+        "chat_template": "",
+        "bos_token": "",
+        "eos_token": "",
+        "build_info": build_info,
+        "webui_settings": {},
+    }
+
+
+def openai_model_entry_with_llama_fields(
+    model_id: str,
+    created: int,
+    *,
+    model_cache_path: str | None,
+) -> dict[str, Any]:
+    """Single /v1/models row with fields the llama webui maps as ApiModelDataEntry."""
+    path = model_cache_path or ""
+    return {
+        "id": model_id,
+        "object": "model",
+        "created": created,
+        "owned_by": "tiles",
+        "in_cache": bool(model_cache_path),
+        "path": path,
+        "status": {"value": "loaded"},
+    }

--- a/server/llamacpp_webui_compat.py
+++ b/server/llamacpp_webui_compat.py
@@ -75,6 +75,8 @@ def _read_n_ctx(model_cache_path: str | None) -> int:
     try:
         with open(p, encoding="utf-8") as f:
             cfg = json.load(f)
+        if not isinstance(cfg, dict):
+            return 8192
         for key in (
             "max_position_embeddings",
             "n_positions",
@@ -84,7 +86,7 @@ def _read_n_ctx(model_cache_path: str | None) -> int:
             v = cfg.get(key)
             if isinstance(v, int) and v > 0:
                 return min(v, 262144)
-    except (OSError, json.JSONDecodeError, TypeError):
+    except (OSError, json.JSONDecodeError, TypeError, AttributeError):
         pass
     return 8192
 

--- a/server/main.py
+++ b/server/main.py
@@ -17,18 +17,11 @@ logger = logging.getLogger("app")
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
-    try:
-        body = await request.json()
-    except Exception:
-        body = None
-
+    # Do not read the request body here: it would consume the stream and can break
+    # POST handlers; omitting bodies also avoids logging prompts
+    client = request.client.host if request.client else None
     logger.info(
-        {
-            "method": request.method,
-            "url": str(request.url),
-            "client": request.client.host,
-            "body": body,
-        }
+        {"method": request.method, "path": request.url.path, "client": client}
     )
 
     response = await call_next(request)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -20,4 +20,14 @@ build-backend = "setuptools.build_meta"
 exclude = ["backend", "backend.*"]
 
 [tool.uv]
-exclude-newer="10 days"
+# Exclude package releases newer than this UTC instant (reproducible resolves).
+exclude-newer = "2026-04-05T00:00:00Z"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]
+
+[tool.pytest.ini_options]
+pythonpath = [".."]
+testpaths = ["tests"]

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -85,8 +85,21 @@ class ChatCompletionRequest(BaseModel):
     @classmethod
     def normalize_max_tokens(cls, v: Any) -> int | None:
         # llama.cpp Web UI sends -1 for "infinite"
-        if v == -1:
+        if v is None:
             return None
+        if isinstance(v, str):
+            try:
+                v = int(v.strip())
+            except ValueError:
+                return v
+        if isinstance(v, bool):
+            raise ValueError("max_tokens must be an integer, not bool")
+        if isinstance(v, int):
+            if v == -1:
+                return None
+            if v < 0:
+                raise ValueError("max_tokens must be >= 0 or -1")
+            return v
         return v
 
 

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -19,7 +19,7 @@ from openresponses_types.types import (
     ToolChoiceParam,
     UserMessageItemParam,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class CompletionRequest(BaseModel):
@@ -34,21 +34,60 @@ class CompletionRequest(BaseModel):
 
 
 class ChatMessage(BaseModel):
+    """OpenAI chat message; content may be a string or multimodal parts (llama Web UI)."""
+
+    model_config = ConfigDict(extra="ignore")
+
     role: str = Field(..., pattern="^(system|user|assistant)$")
-    content: str
+    content: Union[str, List[Any]]
+
+    @field_validator("content", mode="before")
+    @classmethod
+    def normalize_content(cls, v: Any) -> str:
+        if isinstance(v, str):
+            return v
+        if isinstance(v, list):
+            parts: list[str] = []
+            for item in v:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict):
+                    t = item.get("text")
+                    if isinstance(t, str):
+                        parts.append(t)
+                    elif item.get("type") == "text" and isinstance(item.get("text"), str):
+                        parts.append(item["text"])
+            return "\n".join(parts) if parts else ""
+        return str(v)
 
 
 class ChatCompletionRequest(BaseModel):
-    model: str
+    model_config = ConfigDict(extra="ignore")
+
+    # Optional when a model is already loaded via POST /start (llama Web UI single-model mode).
+    model: str | None = None
     messages: List[ChatMessage]
-    chat_start: bool
-    python_code: str
+    chat_start: bool = False
+    python_code: str = ""
+    # CLI memory mode sends this; OpenAI-compatible clients omit it (stateless chat).
+    input: str | None = Field(
+        default=None,
+        description="When set, use legacy memory-agent turn (same host as Tiles CLI memory mode).",
+    )
     max_tokens: int | None = None
     temperature: float | None = 0.7
     top_p: float | None = 0.9
     stream: bool | None = False
     stop: Union[str, List[str]] | None = None
     repetition_penalty: float | None = 1.1
+
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def normalize_max_tokens(cls, v: Any) -> int | None:
+        # llama.cpp Web UI sends -1 for "infinite"
+        if v == -1:
+            return None
+        return v
 
 
 class CompletionResponse(BaseModel):
@@ -82,6 +121,13 @@ class StartRequest(BaseModel):
     memory_path: str
     system_prompt: str
     model_cache_path: str
+
+
+class RouterModelsLoadBody(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    model: str
+    extra_args: List[str] | None = None
 
 
 class downloadRequest(BaseModel):

--- a/server/session_persist.py
+++ b/server/session_persist.py
@@ -1,0 +1,61 @@
+"""Persist last successful model load for restore on next server process start."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, TypedDict
+
+_SESSION_ENV = "TILES_SKIP_SESSION_PERSIST"
+_FILE_ENV = "TILES_SESSION_FILE"
+
+
+class SessionData(TypedDict):
+    model: str
+    model_cache_path: str
+    memory_path: str
+    system_prompt: str
+
+
+def _path() -> Path:
+    raw = os.environ.get(_FILE_ENV)
+    if raw:
+        return Path(raw)
+    return Path.home() / ".tiles" / "server_session.json"
+
+
+def skip_persist() -> bool:
+    return os.environ.get(_SESSION_ENV) == "1"
+
+
+def save(data: SessionData) -> None:
+    if skip_persist():
+        return
+    p = _path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(dict(data), separators=(",", ":"), ensure_ascii=False)
+    tmp = p.parent / f"{p.name}.tmp"
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def load() -> SessionData | None:
+    if skip_persist():
+        return None
+    p = _path()
+    if not p.is_file():
+        return None
+    try:
+        raw: Any = json.loads(p.read_text(encoding="utf-8"))
+        for k in ("model", "model_cache_path", "memory_path", "system_prompt"):
+            if k not in raw or not isinstance(raw[k], str):
+                return None
+        return SessionData(
+            model=raw["model"],
+            model_cache_path=raw["model_cache_path"],
+            memory_path=raw["memory_path"],
+            system_prompt=raw["system_prompt"],
+        )
+    except (OSError, json.JSONDecodeError, TypeError, KeyError):
+        return None

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -14,12 +14,16 @@ import server.runtime as runtime
 @pytest.fixture(autouse=True)
 def reset_api_state():
     """Isolate tests that mutate /start and chat session state."""
+    api._current_model_path = None
+    api._default_max_tokens = None
     api._loaded_model_id = None
     api._loaded_model_cache_path = None
     api._model_loaded_at = None
     api._messages = []
     api._memory_path = ""
     yield
+    api._current_model_path = None
+    api._default_max_tokens = None
     api._loaded_model_id = None
     api._loaded_model_cache_path = None
     api._model_loaded_at = None

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Pytest fixtures for the Tiles inference server."""
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("TILES_SKIP_SESSION_PERSIST", "1")
+
+import pytest
+
+import server.api as api
+import server.runtime as runtime
+
+
+@pytest.fixture(autouse=True)
+def reset_api_state():
+    """Isolate tests that mutate /start and chat session state."""
+    api._loaded_model_id = None
+    api._loaded_model_cache_path = None
+    api._model_loaded_at = None
+    api._messages = []
+    api._memory_path = ""
+    yield
+    api._loaded_model_id = None
+    api._loaded_model_cache_path = None
+    api._model_loaded_at = None
+    api._messages = []
+    api._memory_path = ""
+
+
+@pytest.fixture
+def mock_backend(monkeypatch):
+    """Provide a backend with async streaming and sync completion stubs."""
+    b = MagicMock()
+
+    async def fake_stream(*_a, **_k):
+        yield 'data: {"id":"c","object":"chat.completion.chunk","choices":[{"delta":{"content":"ok"}}]}\n\n'
+        yield "data: [DONE]\n\n"
+
+    b.generate_chat_stream = MagicMock(side_effect=fake_stream)
+    b.complete_openai_chat_completion = MagicMock(
+        return_value={
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "done"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+    )
+    b.get_or_load_model = MagicMock()
+
+    async def fake_resp_stream(*_a, **_k):
+        yield 'data: {"object":"response.chunk"}\n\n'
+        yield "data: [DONE]\n\n"
+
+    b.generate_response_chat_stream = fake_resp_stream
+    b.generate_response_chat = MagicMock(return_value={"id": "r1", "status": "completed"})
+
+    monkeypatch.setattr(runtime, "backend", b)
+    return b

--- a/server/tests/test_llamacpp_webui_compat.py
+++ b/server/tests/test_llamacpp_webui_compat.py
@@ -1,0 +1,18 @@
+"""Tests for llama.cpp Web UI helper helpers."""
+
+import json
+from pathlib import Path
+
+from server.llamacpp_webui_compat import _read_n_ctx
+
+
+def test_read_n_ctx_non_object_json_returns_default(tmp_path: Path):
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert _read_n_ctx(str(tmp_path)) == 8192
+
+
+def test_read_n_ctx_reads_context_length(tmp_path: Path):
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps({"context_length": 4096}), encoding="utf-8")
+    assert _read_n_ctx(str(tmp_path)) == 4096

--- a/server/tests/test_openai_compat.py
+++ b/server/tests/test_openai_compat.py
@@ -1,0 +1,225 @@
+"""Tests for OpenAI-compatible /v1/models and /v1/chat/completions."""
+
+from fastapi.testclient import TestClient
+
+from server.api import app
+
+
+def test_v1_models_empty():
+    client = TestClient(app)
+    r = client.get("/v1/models")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["object"] == "list"
+    assert body["data"] == []
+
+
+def test_health_endpoints():
+    client = TestClient(app)
+    for path in ("/health", "/v1/health"):
+        r = client.get(path)
+        assert r.status_code == 200
+        b = r.json()
+        assert b["status"] == "ok"
+        assert b["tiles"] is True
+        assert "model_loaded" in b
+
+
+def test_models_load_requires_cache_path_env():
+    client = TestClient(app)
+    r = client.post("/models/load", json={"model": "x"})
+    assert r.status_code == 200
+    assert r.json()["success"] is False
+    assert "TILES_MODEL_CACHE_PATH" in r.json()["error"]
+
+
+def test_models_load_with_cache_path_env(mock_backend, monkeypatch):
+    monkeypatch.setenv("TILES_MODEL_CACHE_PATH", "/tmp/mlx-cache")
+    client = TestClient(app)
+    r = client.post("/models/load", json={"model": "demo-model", "extra_args": []})
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+    mock_backend.get_or_load_model.assert_called_once_with("demo-model", "/tmp/mlx-cache")
+
+
+def test_models_unload_stub():
+    client = TestClient(app)
+    r = client.post("/models/unload", json={"model": "x"})
+    assert r.status_code == 200
+    assert r.json()["success"] is False
+
+
+def test_props_for_llamacpp_webui():
+    client = TestClient(app)
+    r = client.get("/props")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["role"] == "model"
+    assert "default_generation_settings" in body
+    assert body["modalities"]["vision"] is False
+
+
+def test_v1_models_after_start(mock_backend):
+    client = TestClient(app)
+    r = client.post(
+        "/start",
+        json={
+            "model": "demo-model",
+            "memory_path": "/tmp/mem",
+            "system_prompt": "You are a test assistant.",
+            "model_cache_path": "/tmp/cache",
+        },
+    )
+    assert r.status_code == 200
+    mock_backend.get_or_load_model.assert_called_once()
+
+    r2 = client.get("/v1/models")
+    assert r2.status_code == 200
+    data = r2.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == "demo-model"
+    assert data[0]["object"] == "model"
+    assert data[0]["owned_by"] == "tiles"
+    assert data[0]["status"]["value"] == "loaded"
+    assert "path" in data[0]
+
+
+def test_chat_completions_openai_stream(mock_backend):
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+        },
+    )
+    assert r.status_code == 200
+    assert "event-stream" in r.headers.get("content-type", "")
+    assert "ok" in r.text
+    mock_backend.generate_chat_stream.assert_called_once()
+
+
+def test_chat_completions_openai_non_stream(mock_backend):
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": False,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["object"] == "chat.completion"
+    assert body["choices"][0]["message"]["content"] == "done"
+    mock_backend.complete_openai_chat_completion.assert_called_once()
+
+
+def test_chat_completions_memory_path_uses_legacy_append(mock_backend):
+    """When `input` is present, behave like Tiles CLI memory mode (append tool result)."""
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "demo-model",
+            "input": "user turn",
+            "chat_start": True,
+            "python_code": "",
+            "messages": [
+                {"role": "assistant", "content": ""},
+                {"role": "user", "content": "hi"},
+            ],
+            "stream": True,
+        },
+    )
+    assert r.status_code == 200
+    mock_backend.generate_chat_stream.assert_called_once()
+    call_args = mock_backend.generate_chat_stream.call_args[0]
+    messages_passed = call_args[0]
+    assert any("result" in m.content for m in messages_passed)
+
+
+def test_chat_completions_rejects_invalid_message_role():
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "m",
+            "messages": [{"role": "tool", "content": "x"}],
+            "stream": False,
+        },
+    )
+    assert r.status_code == 422
+    body = r.json()
+    assert "error" in body
+    assert "message" in body["error"]
+
+
+def test_chat_completions_400_when_no_model_and_none_loaded(mock_backend):
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "x"}], "stream": False},
+    )
+    assert r.status_code == 400
+    assert "POST /start" in r.json()["error"]["message"]
+
+
+def test_chat_completions_uses_loaded_model_when_body_omits_model(mock_backend):
+    """llama.cpp Web UI often omits model in single-model mode; use POST /start model id."""
+    import server.api as api
+
+    api._loaded_model_id = "from-start"
+    try:
+        client = TestClient(app)
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+        assert r.status_code == 200
+        req = mock_backend.generate_chat_stream.call_args[0][1]
+        assert req.model == "from-start"
+    finally:
+        api._loaded_model_id = None
+
+
+def test_chat_completions_accepts_openai_content_array(mock_backend):
+    """llama.cpp Web UI may send multimodal-shaped content arrays; we flatten to text."""
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "demo-model",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hi"}],
+                }
+            ],
+            "stream": True,
+            "max_tokens": -1,
+        },
+    )
+    assert r.status_code == 200
+    mock_backend.generate_chat_stream.assert_called_once()
+    msgs = mock_backend.generate_chat_stream.call_args[0][0]
+    assert msgs[-1].content == "hi"
+
+
+def test_responses_stream_uses_event_stream(mock_backend):
+    client = TestClient(app)
+    r = client.post(
+        "/v1/responses",
+        json={
+            "model": "demo-model",
+            "input": "hello",
+            "stream": True,
+        },
+    )
+    assert r.status_code == 200
+    assert "event-stream" in r.headers.get("content-type", "")

--- a/server/tests/test_openai_compat.py
+++ b/server/tests/test_openai_compat.py
@@ -141,6 +141,21 @@ def test_chat_completions_memory_path_uses_legacy_append(mock_backend):
     assert any("result" in m.content for m in messages_passed)
 
 
+def test_chat_completions_rejects_negative_max_tokens_other_than_minus_one(mock_backend):
+    client = TestClient(app)
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "x"}],
+            "stream": False,
+            "max_tokens": -2,
+        },
+    )
+    assert r.status_code == 422
+    assert "error" in r.json()
+
+
 def test_chat_completions_rejects_invalid_message_role():
     client = TestClient(app)
     r = client.post(

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-03-19T13:23:15.459975Z"
-exclude-newer-span = "P10D"
+exclude-newer = "2026-04-05T00:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -26,14 +25,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -68,14 +67,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -112,11 +111,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.2.0"
+version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
 ]
 
 [[package]]
@@ -130,26 +129,26 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.4.2"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/08/23c84a26716382c89151b5b447b4beb19e3345f3a93d3b73009a71a57ad3/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea", size = 672357, upload-time = "2026-03-13T06:58:51.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/06/e8cf74c3c48e5485c7acc5a990d0d8516cdfb5fdf80f799174f1287cc1b5/hf_xet-1.4.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ac8202ae1e664b2c15cdfc7298cbb25e80301ae596d602ef7870099a126fcad4", size = 3796125, upload-time = "2026-03-13T06:58:33.177Z" },
-    { url = "https://files.pythonhosted.org/packages/66/d4/b73ebab01cbf60777323b7de9ef05550790451eb5172a220d6b9845385ec/hf_xet-1.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6d2f8ee39fa9fba9af929f8c0d0482f8ee6e209179ad14a909b6ad78ffcb7c81", size = 3555985, upload-time = "2026-03-13T06:58:31.797Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/e7/ded6d1bd041c3f2bca9e913a0091adfe32371988e047dd3a68a2463c15a2/hf_xet-1.4.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4642a6cf249c09da8c1f87fe50b24b2a3450b235bf8adb55700b52f0ea6e2eb6", size = 4212085, upload-time = "2026-03-13T06:58:24.323Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c1/a0a44d1f98934f7bdf17f7a915b934f9fca44bb826628c553589900f6df8/hf_xet-1.4.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:769431385e746c92dc05492dde6f687d304584b89c33d79def8367ace06cb555", size = 3988266, upload-time = "2026-03-13T06:58:22.887Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/82/be713b439060e7d1f1d93543c8053d4ef2fe7e6922c5b31642eaa26f3c4b/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c9dd1c1bc4cc56168f81939b0e05b4c36dd2d28c13dc1364b17af89aa0082496", size = 4188513, upload-time = "2026-03-13T06:58:40.858Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a6/cbd4188b22abd80ebd0edbb2b3e87f2633e958983519980815fb8314eae5/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fca58a2ae4e6f6755cc971ac6fcdf777ea9284d7e540e350bb000813b9a3008d", size = 4428287, upload-time = "2026-03-13T06:58:42.601Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/4e/84e45b25e2e3e903ed3db68d7eafa96dae9a1d1f6d0e7fc85120347a852f/hf_xet-1.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:163aab46854ccae0ab6a786f8edecbbfbaa38fcaa0184db6feceebf7000c93c0", size = 3665574, upload-time = "2026-03-13T06:58:53.881Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/71/c5ac2b9a7ae39c14e91973035286e73911c31980fe44e7b1d03730c00adc/hf_xet-1.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:09b138422ecbe50fd0c84d4da5ff537d27d487d3607183cd10e3e53f05188e82", size = 3528760, upload-time = "2026-03-13T06:58:52.187Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/86/b40b83a2ff03ef05c4478d2672b1fc2b9683ff870e2b25f4f3af240f2e7b/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5", size = 3800339, upload-time = "2026-03-13T06:58:36.245Z" },
-    { url = "https://files.pythonhosted.org/packages/64/2e/af4475c32b4378b0e92a587adb1aa3ec53e3450fd3e5fe0372a874531c00/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a", size = 3559664, upload-time = "2026-03-13T06:58:34.787Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c", size = 4217422, upload-time = "2026-03-13T06:58:27.472Z" },
-    { url = "https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271", size = 3992847, upload-time = "2026-03-13T06:58:25.989Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ef/e80815061abff54697239803948abc665c6b1d237102c174f4f7a9a5ffc5/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2", size = 4193843, upload-time = "2026-03-13T06:58:44.59Z" },
-    { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
 ]
 
 [[package]]
@@ -182,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.7.1"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -195,9 +194,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/a8/94ccc0aec97b996a3a68f3e1fa06a4bd7185dd02bf22bfba794a0ade8440/huggingface_hub-1.7.1.tar.gz", hash = "sha256:be38fe66e9b03c027ad755cb9e4b87ff0303c98acf515b5d579690beb0bf3048", size = 722097, upload-time = "2026-03-13T09:36:07.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/bb/62c7aa86f63a05e2f9b96642fdef9b94526a23979820b09f5455deff4983/huggingface_hub-1.9.0.tar.gz", hash = "sha256:0ea5be7a56135c91797cae6ad726e38eaeb6eb4b77cefff5c9d38ba0ecf874f7", size = 750326, upload-time = "2026-04-03T08:35:55.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/75/ca21955d6117a394a482c7862ce96216239d0e3a53133ae8510727a8bcfa/huggingface_hub-1.7.1-py3-none-any.whl", hash = "sha256:38c6cce7419bbde8caac26a45ed22b0cea24152a8961565d70ec21f88752bfaa", size = 616308, upload-time = "2026-03-13T09:36:06.062Z" },
+    { url = "https://files.pythonhosted.org/packages/73/37/0d15d16150e1829f3e90962c99f28257f6de9e526a680b4c6f5acdb54fd2/huggingface_hub-1.9.0-py3-none-any.whl", hash = "sha256:2999328c058d39fd19ab748dd09bd4da2fbaa4f4c1ddea823eab103051e14a1f", size = 637355, upload-time = "2026-04-03T08:35:53.897Z" },
 ]
 
 [[package]]
@@ -207,6 +206,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -324,31 +332,31 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.3"
+version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/d0/1fe47a98ce0df229238b77611340aff92d52691bcbc10583303181abf7fc/numpy-2.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b346845443716c8e542d54112966383b448f4a3ba5c66409771b8c0889485dd3", size = 16665297, upload-time = "2026-03-09T07:56:52.296Z" },
-    { url = "https://files.pythonhosted.org/packages/27/d9/4e7c3f0e68dfa91f21c6fb6cf839bc829ec920688b1ce7ec722b1a6202fb/numpy-2.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2629289168f4897a3c4e23dc98d6f1731f0fc0fe52fb9db19f974041e4cc12b9", size = 14691853, upload-time = "2026-03-09T07:56:54.992Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/66/bd096b13a87549683812b53ab211e6d413497f84e794fb3c39191948da97/numpy-2.4.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bb2e3cf95854233799013779216c57e153c1ee67a0bf92138acca0e429aefaee", size = 5198435, upload-time = "2026-03-09T07:56:57.184Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/2f/687722910b5a5601de2135c891108f51dfc873d8e43c8ed9f4ebb440b4a2/numpy-2.4.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7f3408ff897f8ab07a07fbe2823d7aee6ff644c097cc1f90382511fe982f647f", size = 6546347, upload-time = "2026-03-09T07:56:59.531Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ec/7971c4e98d86c564750393fab8d7d83d0a9432a9d78bb8a163a6dc59967a/numpy-2.4.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:decb0eb8a53c3b009b0962378065589685d66b23467ef5dac16cbe818afde27f", size = 15664626, upload-time = "2026-03-09T07:57:01.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/eb/7daecbea84ec935b7fc732e18f532073064a3816f0932a40a17f3349185f/numpy-2.4.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5f51900414fc9204a0e0da158ba2ac52b75656e7dce7e77fb9f84bfa343b4cc", size = 16608916, upload-time = "2026-03-09T07:57:04.008Z" },
-    { url = "https://files.pythonhosted.org/packages/df/58/2a2b4a817ffd7472dca4421d9f0776898b364154e30c95f42195041dc03b/numpy-2.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6bd06731541f89cdc01b261ba2c9e037f1543df7472517836b78dfb15bd6e476", size = 17015824, upload-time = "2026-03-09T07:57:06.347Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/ca/627a828d44e78a418c55f82dd4caea8ea4a8ef24e5144d9e71016e52fb40/numpy-2.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22654fe6be0e5206f553a9250762c653d3698e46686eee53b399ab90da59bd92", size = 18334581, upload-time = "2026-03-09T07:57:09.114Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/c0/76f93962fc79955fcba30a429b62304332345f22d4daec1cb33653425643/numpy-2.4.3-cp313-cp313-win32.whl", hash = "sha256:d71e379452a2f670ccb689ec801b1218cd3983e253105d6e83780967e899d687", size = 5958618, upload-time = "2026-03-09T07:57:11.432Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/3c/88af0040119209b9b5cb59485fa48b76f372c73068dbf9254784b975ac53/numpy-2.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:0a60e17a14d640f49146cb38e3f105f571318db7826d9b6fef7e4dce758faecd", size = 12312824, upload-time = "2026-03-09T07:57:13.586Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ce/3d07743aced3d173f877c3ef6a454c2174ba42b584ab0b7e6d99374f51ed/numpy-2.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:c9619741e9da2059cd9c3f206110b97583c7152c1dc9f8aafd4beb450ac1c89d", size = 10221218, upload-time = "2026-03-09T07:57:16.183Z" },
-    { url = "https://files.pythonhosted.org/packages/62/09/d96b02a91d09e9d97862f4fc8bfebf5400f567d8eb1fe4b0cc4795679c15/numpy-2.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7aa4e54f6469300ebca1d9eb80acd5253cdfa36f2c03d79a35883687da430875", size = 14819570, upload-time = "2026-03-09T07:57:18.564Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/ca/0b1aba3905fdfa3373d523b2b15b19029f4f3031c87f4066bd9d20ef6c6b/numpy-2.4.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d1b90d840b25874cf5cd20c219af10bac3667db3876d9a495609273ebe679070", size = 5326113, upload-time = "2026-03-09T07:57:21.052Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/63/406e0fd32fcaeb94180fd6a4c41e55736d676c54346b7efbce548b94a914/numpy-2.4.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a749547700de0a20a6718293396ec237bb38218049cfce788e08fcb716e8cf73", size = 6646370, upload-time = "2026-03-09T07:57:22.804Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/d0/10f7dc157d4b37af92720a196be6f54f889e90dcd30dce9dc657ed92c257/numpy-2.4.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f3c4a151a2e529adf49c1d54f0f57ff8f9b233ee4d44af623a81553ab86368", size = 15723499, upload-time = "2026-03-09T07:57:24.693Z" },
-    { url = "https://files.pythonhosted.org/packages/66/f1/d1c2bf1161396629701bc284d958dc1efa3a5a542aab83cf11ee6eb4cba5/numpy-2.4.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22c31dc07025123aedf7f2db9e91783df13f1776dc52c6b22c620870dc0fab22", size = 16657164, upload-time = "2026-03-09T07:57:27.676Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/cca19230b740af199ac47331a21c71e7a3d0ba59661350483c1600d28c37/numpy-2.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:148d59127ac95979d6f07e4d460f934ebdd6eed641db9c0db6c73026f2b2101a", size = 17081544, upload-time = "2026-03-09T07:57:30.664Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c5/9602b0cbb703a0936fb40f8a95407e8171935b15846de2f0776e08af04c7/numpy-2.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a97cbf7e905c435865c2d939af3d93f99d18eaaa3cabe4256f4304fb51604349", size = 18380290, upload-time = "2026-03-09T07:57:33.763Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/81/9f24708953cd30be9ee36ec4778f4b112b45165812f2ada4cc5ea1c1f254/numpy-2.4.3-cp313-cp313t-win32.whl", hash = "sha256:be3b8487d725a77acccc9924f65fd8bce9af7fac8c9820df1049424a2115af6c", size = 6082814, upload-time = "2026-03-09T07:57:36.491Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/9e/52f6eaa13e1a799f0ab79066c17f7016a4a8ae0c1aefa58c82b4dab690b4/numpy-2.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1ec84fd7c8e652b0f4aaaf2e6e9cc8eaa9b1b80a537e06b2e3a2fb176eedcb26", size = 12452673, upload-time = "2026-03-09T07:57:38.281Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/04/b8cece6ead0b30c9fbd99bb835ad7ea0112ac5f39f069788c5558e3b1ab2/numpy-2.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:120df8c0a81ebbf5b9020c91439fccd85f5e018a927a39f624845be194a2be02", size = 10290907, upload-time = "2026-03-09T07:57:40.747Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
 ]
 
 [[package]]
@@ -414,18 +422,27 @@ wheels = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "7.34.0"
+name = "pluggy"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/00/04a2ab36b70a52d0356852979e08b44edde0435f2115dc66e25f2100f3ab/protobuf-7.34.0.tar.gz", hash = "sha256:3871a3df67c710aaf7bb8d214cc997342e63ceebd940c8c7fc65c9b3d697591a", size = 454726, upload-time = "2026-02-27T00:30:25.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/c4/6322ab5c8f279c4c358bc14eb8aefc0550b97222a39f04eb3c1af7a830fa/protobuf-7.34.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e329966799f2c271d5e05e236459fe1cbfdb8755aaa3b0914fa60947ddea408", size = 429248, upload-time = "2026-02-27T00:30:14.924Z" },
-    { url = "https://files.pythonhosted.org/packages/45/99/b029bbbc61e8937545da5b79aa405ab2d9cf307a728f8c9459ad60d7a481/protobuf-7.34.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:9d7a5005fb96f3c1e64f397f91500b0eb371b28da81296ae73a6b08a5b76cdd6", size = 325753, upload-time = "2026-02-27T00:30:17.247Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/79/09f02671eb75b251c5550a1c48e7b3d4b0623efd7c95a15a50f6f9fc1e2e/protobuf-7.34.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4a72a8ec94e7a9f7ef7fe818ed26d073305f347f8b3b5ba31e22f81fd85fca02", size = 340200, upload-time = "2026-02-27T00:30:18.672Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/57/89727baef7578897af5ed166735ceb315819f1c184da8c3441271dbcfde7/protobuf-7.34.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:964cf977e07f479c0697964e83deda72bcbc75c3badab506fb061b352d991b01", size = 324268, upload-time = "2026-02-27T00:30:20.088Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/3e/38ff2ddee5cc946f575c9d8cc822e34bde205cf61acf8099ad88ef19d7d2/protobuf-7.34.0-cp310-abi3-win32.whl", hash = "sha256:f791ec509707a1d91bd02e07df157e75e4fb9fbdad12a81b7396201ec244e2e3", size = 426628, upload-time = "2026-02-27T00:30:21.555Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/71/7c32eaf34a61a1bae1b62a2ac4ffe09b8d1bb0cf93ad505f42040023db89/protobuf-7.34.0-cp310-abi3-win_amd64.whl", hash = "sha256:9f9079f1dde4e32342ecbd1c118d76367090d4aaa19da78230c38101c5b3dd40", size = 437901, upload-time = "2026-02-27T00:30:22.836Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/e7/14dc9366696dcb53a413449881743426ed289d687bcf3d5aee4726c32ebb/protobuf-7.34.0-py3-none-any.whl", hash = "sha256:e3b914dd77fa33fa06ab2baa97937746ab25695f389869afdf03e81f34e45dc7", size = 170716, upload-time = "2026-02-27T00:30:23.994Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
 ]
 
 [[package]]
@@ -470,11 +487,27 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -511,42 +544,42 @@ wheels = [
 
 [[package]]
 name = "regex"
-version = "2026.2.28"
+version = "2026.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/71/41455aa99a5a5ac1eaf311f5d8efd9ce6433c03ac1e0962de163350d0d97/regex-2026.2.28.tar.gz", hash = "sha256:a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2", size = 415184, upload-time = "2026-02-28T02:19:42.792Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f6/dc9ef48c61b79c8201585bf37fa70cd781977da86e466cd94e8e95d2443b/regex-2026.2.28-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6d63a07e5ec8ce7184452cb00c41c37b49e67dc4f73b2955b5b8e782ea970784", size = 489311, upload-time = "2026-02-28T02:17:22.591Z" },
-    { url = "https://files.pythonhosted.org/packages/95/c8/c20390f2232d3f7956f420f4ef1852608ad57aa26c3dd78516cb9f3dc913/regex-2026.2.28-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e59bc8f30414d283ae8ee1617b13d8112e7135cb92830f0ec3688cb29152585a", size = 291285, upload-time = "2026-02-28T02:17:24.355Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/a6/ba1068a631ebd71a230e7d8013fcd284b7c89c35f46f34a7da02082141b1/regex-2026.2.28-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:de0cf053139f96219ccfabb4a8dd2d217c8c82cb206c91d9f109f3f552d6b43d", size = 289051, upload-time = "2026-02-28T02:17:26.722Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/1b/7cc3b7af4c244c204b7a80924bd3d85aecd9ba5bc82b485c5806ee8cda9e/regex-2026.2.28-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb4db2f17e6484904f986c5a657cec85574c76b5c5e61c7aae9ffa1bc6224f95", size = 796842, upload-time = "2026-02-28T02:17:29.064Z" },
-    { url = "https://files.pythonhosted.org/packages/24/87/26bd03efc60e0d772ac1e7b60a2e6325af98d974e2358f659c507d3c76db/regex-2026.2.28-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:52b017b35ac2214d0db5f4f90e303634dc44e4aba4bd6235a27f97ecbe5b0472", size = 863083, upload-time = "2026-02-28T02:17:31.363Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/54/aeaf4afb1aa0a65e40de52a61dc2ac5b00a83c6cb081c8a1d0dda74f3010/regex-2026.2.28-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:69fc560ccbf08a09dc9b52ab69cacfae51e0ed80dc5693078bdc97db2f91ae96", size = 909412, upload-time = "2026-02-28T02:17:33.248Z" },
-    { url = "https://files.pythonhosted.org/packages/12/2f/049901def913954e640d199bbc6a7ca2902b6aeda0e5da9d17f114100ec2/regex-2026.2.28-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e61eea47230eba62a31f3e8a0e3164d0f37ef9f40529fb2c79361bc6b53d2a92", size = 802101, upload-time = "2026-02-28T02:17:35.053Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a5/512fb9ff7f5b15ea204bb1967ebb649059446decacccb201381f9fa6aad4/regex-2026.2.28-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4f5c0b182ad4269e7381b7c27fdb0408399881f7a92a4624fd5487f2971dfc11", size = 775260, upload-time = "2026-02-28T02:17:37.692Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/9a92935878aba19bd72706b9db5646a6f993d99b3f6ed42c02ec8beb1d61/regex-2026.2.28-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:96f6269a2882fbb0ee76967116b83679dc628e68eaea44e90884b8d53d833881", size = 784311, upload-time = "2026-02-28T02:17:39.855Z" },
-    { url = "https://files.pythonhosted.org/packages/09/d3/fc51a8a738a49a6b6499626580554c9466d3ea561f2b72cfdc72e4149773/regex-2026.2.28-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b5acd4b6a95f37c3c3828e5d053a7d4edaedb85de551db0153754924cb7c83e3", size = 856876, upload-time = "2026-02-28T02:17:42.317Z" },
-    { url = "https://files.pythonhosted.org/packages/08/b7/2e641f3d084b120ca4c52e8c762a78da0b32bf03ef546330db3e2635dc5f/regex-2026.2.28-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2234059cfe33d9813a3677ef7667999caea9eeaa83fef98eb6ce15c6cf9e0215", size = 763632, upload-time = "2026-02-28T02:17:45.073Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/6d/0009021d97e79ee99f3d8641f0a8d001eed23479ade4c3125a5480bf3e2d/regex-2026.2.28-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c15af43c72a7fb0c97cbc66fa36a43546eddc5c06a662b64a0cbf30d6ac40944", size = 849320, upload-time = "2026-02-28T02:17:47.192Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7a/51cfbad5758f8edae430cb21961a9c8d04bce1dae4d2d18d4186eec7cfa1/regex-2026.2.28-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9185cc63359862a6e80fe97f696e04b0ad9a11c4ac0a4a927f979f611bfe3768", size = 790152, upload-time = "2026-02-28T02:17:49.067Z" },
-    { url = "https://files.pythonhosted.org/packages/90/3d/a83e2b6b3daa142acb8c41d51de3876186307d5cb7490087031747662500/regex-2026.2.28-cp313-cp313-win32.whl", hash = "sha256:fb66e5245db9652abd7196ace599b04d9c0e4aa7c8f0e2803938377835780081", size = 266398, upload-time = "2026-02-28T02:17:50.744Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4f/16e9ebb1fe5425e11b9596c8d57bf8877dcb32391da0bfd33742e3290637/regex-2026.2.28-cp313-cp313-win_amd64.whl", hash = "sha256:71a911098be38c859ceb3f9a9ce43f4ed9f4c6720ad8684a066ea246b76ad9ff", size = 277282, upload-time = "2026-02-28T02:17:53.074Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b4/92851335332810c5a89723bf7a7e35c7209f90b7d4160024501717b28cc9/regex-2026.2.28-cp313-cp313-win_arm64.whl", hash = "sha256:39bb5727650b9a0275c6a6690f9bb3fe693a7e6cc5c3155b1240aedf8926423e", size = 270382, upload-time = "2026-02-28T02:17:54.888Z" },
-    { url = "https://files.pythonhosted.org/packages/24/07/6c7e4cec1e585959e96cbc24299d97e4437a81173217af54f1804994e911/regex-2026.2.28-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:97054c55db06ab020342cc0d35d6f62a465fa7662871190175f1ad6c655c028f", size = 492541, upload-time = "2026-02-28T02:17:56.813Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/13/55eb22ada7f43d4f4bb3815b6132183ebc331c81bd496e2d1f3b8d862e0d/regex-2026.2.28-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0d25a10811de831c2baa6aef3c0be91622f44dd8d31dd12e69f6398efb15e48b", size = 292984, upload-time = "2026-02-28T02:17:58.538Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/c301f8cb29ce9644a5ef85104c59244e6e7e90994a0f458da4d39baa8e17/regex-2026.2.28-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d6cfe798d8da41bb1862ed6e0cba14003d387c3c0c4a5d45591076ae9f0ce2f8", size = 291509, upload-time = "2026-02-28T02:18:00.208Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/43/aabe384ec1994b91796e903582427bc2ffaed9c4103819ed3c16d8e749f3/regex-2026.2.28-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd0ce43e71d825b7c0661f9c54d4d74bd97c56c3fd102a8985bcfea48236bacb", size = 809429, upload-time = "2026-02-28T02:18:02.328Z" },
-    { url = "https://files.pythonhosted.org/packages/04/b8/8d2d987a816720c4f3109cee7c06a4b24ad0e02d4fc74919ab619e543737/regex-2026.2.28-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00945d007fd74a9084d2ab79b695b595c6b7ba3698972fadd43e23230c6979c1", size = 869422, upload-time = "2026-02-28T02:18:04.23Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ad/2c004509e763c0c3719f97c03eca26473bffb3868d54c5f280b8cd4f9e3d/regex-2026.2.28-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bec23c11cbbf09a4df32fe50d57cbdd777bc442269b6e39a1775654f1c95dee2", size = 915175, upload-time = "2026-02-28T02:18:06.791Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c2/fd429066da487ef555a9da73bf214894aec77fc8c66a261ee355a69871a8/regex-2026.2.28-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5cdcc17d935c8f9d3f4db5c2ebe2640c332e3822ad5d23c2f8e0228e6947943a", size = 812044, upload-time = "2026-02-28T02:18:08.736Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/ca/feedb7055c62a3f7f659971bf45f0e0a87544b6b0cf462884761453f97c5/regex-2026.2.28-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a448af01e3d8031c89c5d902040b124a5e921a25c4e5e07a861ca591ce429341", size = 782056, upload-time = "2026-02-28T02:18:10.777Z" },
-    { url = "https://files.pythonhosted.org/packages/95/30/1aa959ed0d25c1dd7dd5047ea8ba482ceaef38ce363c401fd32a6b923e60/regex-2026.2.28-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:10d28e19bd4888e4abf43bd3925f3c134c52fdf7259219003588a42e24c2aa25", size = 798743, upload-time = "2026-02-28T02:18:13.025Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/1f/dadb9cf359004784051c897dcf4d5d79895f73a1bbb7b827abaa4814ae80/regex-2026.2.28-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:99985a2c277dcb9ccb63f937451af5d65177af1efdeb8173ac55b61095a0a05c", size = 864633, upload-time = "2026-02-28T02:18:16.84Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/f1/b9a25eb24e1cf79890f09e6ec971ee5b511519f1851de3453bc04f6c902b/regex-2026.2.28-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e1e7b24cb3ae9953a560c563045d1ba56ee4749fbd05cf21ba571069bd7be81b", size = 770862, upload-time = "2026-02-28T02:18:18.892Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9a/c5cb10b7aa6f182f9247a30cc9527e326601f46f4df864ac6db588d11fcd/regex-2026.2.28-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d8511a01d0e4ee1992eb3ba19e09bc1866fe03f05129c3aec3fdc4cbc77aad3f", size = 854788, upload-time = "2026-02-28T02:18:21.475Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/50/414ba0731c4bd40b011fa4703b2cc86879ec060c64f2a906e65a56452589/regex-2026.2.28-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:aaffaecffcd2479ce87aa1e74076c221700b7c804e48e98e62500ee748f0f550", size = 800184, upload-time = "2026-02-28T02:18:23.492Z" },
-    { url = "https://files.pythonhosted.org/packages/69/50/0c7290987f97e7e6830b0d853f69dc4dc5852c934aae63e7fdcd76b4c383/regex-2026.2.28-cp313-cp313t-win32.whl", hash = "sha256:ef77bdde9c9eba3f7fa5b58084b29bbcc74bcf55fdbeaa67c102a35b5bd7e7cc", size = 269137, upload-time = "2026-02-28T02:18:25.375Z" },
-    { url = "https://files.pythonhosted.org/packages/68/80/ef26ff90e74ceb4051ad6efcbbb8a4be965184a57e879ebcbdef327d18fa/regex-2026.2.28-cp313-cp313t-win_amd64.whl", hash = "sha256:98adf340100cbe6fbaf8e6dc75e28f2c191b1be50ffefe292fb0e6f6eefdb0d8", size = 280682, upload-time = "2026-02-28T02:18:27.205Z" },
-    { url = "https://files.pythonhosted.org/packages/69/8b/fbad9c52e83ffe8f97e3ed1aa0516e6dff6bb633a41da9e64645bc7efdc5/regex-2026.2.28-cp313-cp313t-win_arm64.whl", hash = "sha256:2fb950ac1d88e6b6a9414381f403797b236f9fa17e1eee07683af72b1634207b", size = 271735, upload-time = "2026-02-28T02:18:29.015Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/83/c4373bc5f31f2cf4b66f9b7c31005bd87fe66f0dce17701f7db4ee79ee29/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943", size = 490273, upload-time = "2026-04-03T20:54:11.202Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f8/fe62afbcc3cf4ad4ac9adeaafd98aa747869ae12d3e8e2ac293d0593c435/regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031", size = 291954, upload-time = "2026-04-03T20:54:13.412Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/92/4712b9fe6a33d232eeb1c189484b80c6c4b8422b90e766e1195d6e758207/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7", size = 289487, upload-time = "2026-04-03T20:54:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2c/f83b93f85e01168f1070f045a42d4c937b69fdb8dd7ae82d307253f7e36e/regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17", size = 796646, upload-time = "2026-04-03T20:54:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/df/55/61a2e17bf0c4dc57e11caf8dd11771280d8aaa361785f9e3bc40d653f4a7/regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17", size = 865904, upload-time = "2026-04-03T20:54:20.019Z" },
+    { url = "https://files.pythonhosted.org/packages/45/32/1ac8ed1b5a346b5993a3d256abe0a0f03b0b73c8cc88d928537368ac65b6/regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae", size = 912304, upload-time = "2026-04-03T20:54:22.403Z" },
+    { url = "https://files.pythonhosted.org/packages/26/47/2ee5c613ab546f0eddebf9905d23e07beb933416b1246c2d8791d01979b4/regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e", size = 801126, upload-time = "2026-04-03T20:54:24.308Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cd/41dacd129ca9fd20bd7d02f83e0fad83e034ac8a084ec369c90f55ef37e2/regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d", size = 776772, upload-time = "2026-04-03T20:54:26.319Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5af0b588174cb5f46041fa7dd64d3fd5cd2fe51f18766703d1edc387f324/regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27", size = 785228, upload-time = "2026-04-03T20:54:28.387Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3b/f5a72b7045bd59575fc33bf1345f156fcfd5a8484aea6ad84b12c5a82114/regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf", size = 860032, upload-time = "2026-04-03T20:54:30.641Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a4/72a317003d6fcd7a573584a85f59f525dfe8f67e355ca74eb6b53d66a5e2/regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0", size = 765714, upload-time = "2026-04-03T20:54:32.789Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1e/5672e16f34dbbcb2560cc7e6a2fbb26dfa8b270711e730101da4423d3973/regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa", size = 852078, upload-time = "2026-04-03T20:54:34.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/c813f0af7c6cc7ed7b9558bac2e5120b60ad0fa48f813e4d4bd55446f214/regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b", size = 789181, upload-time = "2026-04-03T20:54:36.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6d/a344608d1adbd2a95090ddd906cec09a11be0e6517e878d02a5123e0917f/regex-2026.4.4-cp313-cp313-win32.whl", hash = "sha256:05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62", size = 266690, upload-time = "2026-04-03T20:54:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/54049f89b46235ca6f45cd6c88668a7050e77d4a15555e47dd40fde75263/regex-2026.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81", size = 277733, upload-time = "2026-04-03T20:54:40.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/21/61366a8e20f4d43fb597708cac7f0e2baadb491ecc9549b4980b2be27d16/regex-2026.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427", size = 270565, upload-time = "2026-04-03T20:54:41.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/3a2b9672433bef02f5d39aa1143ca2c08f311c1d041c464a42be9ae648dc/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c", size = 494126, upload-time = "2026-04-03T20:54:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/4b/c132a4f4fe18ad3340d89fcb56235132b69559136036b845be3c073142ed/regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141", size = 293882, upload-time = "2026-04-03T20:54:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/eaa38092ce7a023656280f2341dbbd4ad5f05d780a70abba7bb4f4bea54c/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717", size = 292334, upload-time = "2026-04-03T20:54:47.051Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f6/dd38146af1392dac33db7074ab331cec23cced3759167735c42c5460a243/regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07", size = 811691, upload-time = "2026-04-03T20:54:49.074Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/dc54c2e69f5eeec50601054998ec3690d5344277e782bd717e49867c1d29/regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca", size = 871227, upload-time = "2026-04-03T20:54:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/af/cb16bd5dc61621e27df919a4449bbb7e5a1034c34d307e0a706e9cc0f3e3/regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520", size = 917435, upload-time = "2026-04-03T20:54:52.994Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/8b260897f22996b666edd9402861668f45a2ca259f665ac029e6104a2d7d/regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883", size = 816358, upload-time = "2026-04-03T20:54:54.884Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/60/775f7f72a510ef238254906c2f3d737fc80b16ca85f07d20e318d2eea894/regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b", size = 785549, upload-time = "2026-04-03T20:54:57.01Z" },
+    { url = "https://files.pythonhosted.org/packages/58/42/34d289b3627c03cf381e44da534a0021664188fa49ba41513da0b4ec6776/regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1", size = 801364, upload-time = "2026-04-03T20:54:58.981Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/20/f6ecf319b382a8f1ab529e898b222c3f30600fcede7834733c26279e7465/regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b", size = 866221, upload-time = "2026-04-03T20:55:00.88Z" },
+    { url = "https://files.pythonhosted.org/packages/92/6a/9f16d3609d549bd96d7a0b2aee1625d7512ba6a03efc01652149ef88e74d/regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff", size = 772530, upload-time = "2026-04-03T20:55:03.213Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f6/aa9768bc96a4c361ac96419fbaf2dcdc33970bb813df3ba9b09d5d7b6d96/regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb", size = 856989, upload-time = "2026-04-03T20:55:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/c671db3556be2473ae3e4bb7a297c518d281452871501221251ea4ecba57/regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4", size = 803241, upload-time = "2026-04-03T20:55:07.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/83e3b1d89fa4f6e5a1bc97b4abd4a9a97b3c1ac7854164f694f5f0ba98a0/regex-2026.4.4-cp313-cp313t-win32.whl", hash = "sha256:e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa", size = 269921, upload-time = "2026-04-03T20:55:09.62Z" },
+    { url = "https://files.pythonhosted.org/packages/28/07/077c387121f42cdb4d92b1301133c0d93b5709d096d1669ab847dda9fe2e/regex-2026.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0", size = 281240, upload-time = "2026-04-03T20:55:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/ead4a4abc7c59a4d882662aa292ca02c8b617f30b6e163bc1728879e9353/regex-2026.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe", size = 272440, upload-time = "2026-04-03T20:55:13.365Z" },
 ]
 
 [[package]]
@@ -621,6 +654,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "black", specifier = "==25.9.0" },
@@ -630,6 +668,9 @@ requires-dist = [
     { name = "openresponses-types" },
     { name = "uvicorn", specifier = "==0.38.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "shellingham"
@@ -692,7 +733,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.3.0"
+version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -705,9 +746,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9d/fb46e729b461985f41a5740167688b924a4019141e5c164bea77548d3d9e/transformers-5.5.0.tar.gz", hash = "sha256:c8db656cf51c600cd8c75f06b20ef85c72e8b8ff9abc880c5d3e8bc70e0ddcbd", size = 8237745, upload-time = "2026-04-02T16:13:08.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827, upload-time = "2026-03-04T17:41:42.722Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/28/35f7411ff80a3640c1f4fc907dcbb6a65061ebb82f66950e38bfc9f7f740/transformers-5.5.0-py3-none-any.whl", hash = "sha256:821a9ff0961abbb29eb1eb686d78df1c85929fdf213a3fe49dc6bd94f9efa944", size = 10245591, upload-time = "2026-04-02T16:13:03.462Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull request: OpenAI-compatible HTTP API + llama.cpp Web UI hooks
## Summary
Extends the Tiles Python inference server so OpenAI-style clients and the **ggml-org llama.cpp SvelteKit Web UI** can talk to Tiles (MLX backend) over HTTP, while keeping the existing Tiles CLI flow (`POST /start`, memory-mode chat) intact.
## Motivation
- **Web UI:** Developers want to use the stock llama.cpp Web UI against Tiles without running `llama-server`; the UI expects `GET /props`, enriched `/v1/models` rows, optional `POST /models/load`, OpenAI chat SSE, and `timings` on the final stream chunk.
- **CLI parity:** Session survives server restarts where appropriate; streaming responses still expose `metrics` for the Rust CLI’s memory-mode benchmark line.
- **Operations:** Health endpoints and predictable error bodies for `/v1/*` improve scripting and UI error dialogs.
## What changed
### API (`server/api.py`, `server/main.py`)
- **Lifespan:** On startup, restore last model from `~/.tiles/server_session.json` if present; optional **`TILES_BOOTSTRAP_MODEL`** + **`TILES_BOOTSTRAP_MODEL_CACHE_PATH`** (and optional memory/system prompt env) to load without a prior `/start`.
- **`POST /start`:** After successful load, persist session; shared **`_apply_loaded_session`** used by `/start`, restore, bootstrap, and `/models/load`.
- **`POST /models/load`:** For the Web UI’s `{"model": "<id>"}` body; MLX directory from **`TILES_MODEL_CACHE_PATH`** or **`TILES_BOOTSTRAP_MODEL_CACHE_PATH`**.
- **`GET /props`**, **`GET /v1/models`**, **`GET /health`** / **`GET /v1/health`**, router stubs **`POST /models/load`** (implemented) / **`POST /models/unload`** (stub).
- **`POST /v1/chat/completions`:** Resolved `model`, optional `input` memory path, OpenAI-shaped 422/400/500 for `/v1/*`, CORS for browser dev.
- **Middleware:** Request body is not read in logging middleware (avoids consuming stream and logging prompts).
### Compatibility helpers
- **`server/llamacpp_webui_compat.py`:** `/props`-shaped JSON and `/v1/models` entries with `path`, `status`, `in_cache` expected by the Web UI.
### Session persistence
- **`server/session_persist.py`:** JSON file under **`~/.tiles/server_session.json`** (override with **`TILES_SESSION_FILE`**); disabled in tests via **`TILES_SKIP_SESSION_PERSIST=1`**. Atomic write (temp + replace).
### Streaming / metrics (`server/backend/mlx.py`)
- Final SSE chunk and non-streaming completion include:
  - **`timings`** (`predicted_n`, `predicted_ms`) for llama Web UI token/s UI.
  - **`metrics`** (`ttft_ms`, `total_tokens`, `tokens_per_second`, `total_latency_s`) for Tiles CLI memory mode.
### Schemas (`server/schemas.py`)
- `ChatCompletionRequest` / `ChatMessage` adjustments for Web UI (optional `model`, multimodal `content` list, `extra="ignore"`, `max_tokens: -1` → unlimited).
- **`RouterModelsLoadBody`** for `/models/load`.
### Tests
- **`server/tests/test_openai_compat.py`**, **`server/tests/conftest.py`:** Cover health, props, models, chat stream, errors, `/models/load` with env path.
- **`just test-server`:** `uv run --project server --with pytest pytest server/tests/` so **pytest is not added to `uv.lock`** (keeps lockfile identical to `main`).
### Dev script
- **`scripts/phase2_llamacpp_webui.sh`** + **`just webui-llamacpp`:** Clone/patch llama.cpp Web UI Vite proxy to **`TILES_BACKEND`** (default `http://127.0.0.1:6969`), `npm run dev`.
## How to test
```bash
cd /path/to/tiles
just test-server
just serve   # terminal 1
just webui-llamacpp   # terminal 2 — load model per Tiles docs (POST /start, session, bootstrap, or TILES_MODEL_CACHE_PATH + UI load)
```
## Configuration reference
| Variable | Purpose |
|----------|---------|
| `TILES_SESSION_FILE` | Override path for session JSON |
| `TILES_SKIP_SESSION_PERSIST=1` | Disable read/write (tests) |
| `TILES_BOOTSTRAP_MODEL` / `TILES_BOOTSTRAP_MODEL_CACHE_PATH` | Auto-load on startup if no session |
| `TILES_BOOTSTRAP_MEMORY_PATH` / `TILES_BOOTSTRAP_SYSTEM_PROMPT` | Optional bootstrap extras |
| `TILES_MODEL_CACHE_PATH` | MLX directory for Web UI `POST /models/load` |
