### PR TITLE
fix: REPL breaking due to BROKE PIPE issue on SIGINT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "endian-type"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "enum-as-inner"
@@ -2285,17 +2296,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "ff"
@@ -4054,9 +4054,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -4599,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -5590,9 +5590,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radix_trie"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
  "endian-type",
  "nibble_vec",
@@ -6133,14 +6133,13 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyline"
-version = "17.0.2"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
 dependencies = [
  "bitflags",
  "cfg-if",
  "clipboard-win",
- "fd-lock",
  "home",
  "libc",
  "log",
@@ -6150,7 +6149,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6953,6 +6952,7 @@ dependencies = [
  "axum-macros",
  "chacha20poly1305",
  "clap",
+ "ctrlc",
  "data-encoding",
  "env_logger",
  "futures-util",
@@ -6963,6 +6963,7 @@ dependencies = [
  "iroh-gossip",
  "iroh-tickets",
  "keyring",
+ "libc",
  "log",
  "owo-colors",
  "postcard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6940,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "tiles"
-version = "0.4.10"
+version = "0.4.11-rc.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/server/backend/mlx.py
+++ b/server/backend/mlx.py
@@ -483,7 +483,7 @@ def _process_output_item_added(
     event_name = "response.output_item.added"
     if type == "function_call":
         if not tool_name:
-            raise ValueError("tool call is missing a tool name")
+            print("Tool name is empty")
         item_chunk = {
             "type": type,
             "id": id,

--- a/server/backend/mlx_runner.py
+++ b/server/backend/mlx_runner.py
@@ -505,7 +505,10 @@ class MLXRunner:
 
             if is_commentary is None and parser.current_channel == "commentary":
                 is_commentary = True
-                yield ToolCallStart(name=parser.current_recipient or "")
+                if not parser.current_recipient:
+                    # No business with an empty tool name
+                    continue
+                yield ToolCallStart(name=parser.current_recipient or "bash")
 
             if is_final is None and parser.current_channel == "final":
                 is_final = True

--- a/server/backend/mlx_runner.py
+++ b/server/backend/mlx_runner.py
@@ -504,10 +504,10 @@ class MLXRunner:
                 yield "**[Reasoning]**\n\n"
 
             if is_commentary is None and parser.current_channel == "commentary":
-                is_commentary = True
                 if not parser.current_recipient:
                     # No business with an empty tool name
                     continue
+                is_commentary = True
                 yield ToolCallStart(name=parser.current_recipient or "bash")
 
             if is_final is None and parser.current_channel == "final":

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -9,10 +9,10 @@ dependencies = [
     "mlx-lm==0.31.0",
     "black==25.9.0",
     # "oss-harmony",
-    # "openai-harmony==0.0.8",
+    "openai-harmony==0.0.8",
     "httpx==0.28.1",
     "openresponses-types",
-    "oss-harmony @ git+https://github.com/oss-harmony/harmony.git@main"
+    # "oss-harmony @ git+https://github.com/oss-harmony/harmony.git@main"
 ]
 
 [build-system]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -360,6 +360,29 @@ wheels = [
 ]
 
 [[package]]
+name = "openai-harmony"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/c6/2502f416d46be3ec08bb66d696cccffb57781a499e3ff2e4d7c174af4e8f/openai_harmony-0.0.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:029ec25ca74abe48fdb58eb9fdd2a8c1618581fc33ce8e5653f8a1ffbfbd9326", size = 2627806, upload-time = "2025-11-05T19:06:57.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d2/ce6953ca87db9cae3e775024184da7d1c5cb88cead19a2d75b42f00a959c/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4f709815924ec325b9a890e6ab2bbb0ceec8e319a4e257328eb752cf36b2efc", size = 2948463, upload-time = "2025-11-05T19:06:48.17Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4c/b553c9651662d6ce102ca7f3629d268b23df1abe5841e24bed81e8a8e949/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5cfcfd963b50a41fc656c84d3440ca6eecdccd6c552158ce790b8f2e33dfb5a9", size = 2704083, upload-time = "2025-11-05T19:06:50.205Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/af/4eec8f9ab9c27bcdb444460c72cf43011d176fc44c79d6e113094ca1e152/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a3a16972aa1cee38ea958470cd04ac9a2d5ac38fdcf77ab686611246220c158", size = 2959765, upload-time = "2025-11-05T19:06:53.62Z" },
+    { url = "https://files.pythonhosted.org/packages/11/3c/33f3374e4624e0e776f6b13b73c45a7ead7f9c4529f8369ed5bfcaa30cac/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4d5cfa168e74d08f8ba6d58a7e49bc7daef4d58951ec69b66b0d56f4927a68d", size = 3427031, upload-time = "2025-11-05T19:06:51.829Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3f/1a192b93bb47c6b44cd98ba8cc1d3d2a9308f1bb700c3017e6352da11bda/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c007d277218a50db8839e599ed78e0fffe5130f614c3f6d93ae257f282071a29", size = 2953260, upload-time = "2025-11-05T19:06:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/93b582cad3531797c3db7c2db5400fd841538ccddfd9f5e3df61be99a630/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8565d4f5a0638da1bffde29832ed63c9e695c558611053add3b2dc0b56c92dbc", size = 3127044, upload-time = "2025-11-05T19:06:59.553Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/10/4327dbf87f75ae813405fd9a9b4a5cde63d506ffed0a096a440a4cabd89c/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:cbaa3bda75ef0d8836e1f8cc84af62f971b1d756d740efc95c38c3e04c0bfde2", size = 2932931, upload-time = "2025-11-05T19:07:01.437Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c8/1774eec4f6f360ef57618fb8f52e3d3af245b2491bd0297513aa09eec04b/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:772922a9bd24e133950fad71eb1550836f415a88e8c77870e12d0c3bd688ddc2", size = 2996140, upload-time = "2025-11-05T19:07:03.438Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c3/3d1e01e2dba517a91760e4a03e4f20ffc75039a6fe584d0e6f9b5c78fd15/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:007b0476a1f331f8130783f901f1da6f5a7057af1a4891f1b6a31dec364189b5", size = 3205080, upload-time = "2025-11-05T19:07:05.078Z" },
+    { url = "https://files.pythonhosted.org/packages/14/63/119de431572d7c70a7bf1037034a9be6ed0a7502a7498ba7302bca5b3242/openai_harmony-0.0.8-cp38-abi3-win32.whl", hash = "sha256:a9b5f893326b28d9e935ade14b4f655f5a840942473bc89b201c25f7a15af9cf", size = 2082457, upload-time = "2025-11-05T19:07:09.631Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/c83cf5a206c263ee70448a5ae4264682555f4d0b5bed0d2cc6ca1108103d/openai_harmony-0.0.8-cp38-abi3-win_amd64.whl", hash = "sha256:39d44f0d8f466bd56698e7ead708bead3141e27b9b87e3ab7d5a6d0e4a869ee5", size = 2438369, upload-time = "2025-11-05T19:07:08.1Z" },
+]
+
+[[package]]
 name = "openresponses-types"
 version = "2.3.0.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -369,14 +392,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/26/b612c3215f5599714fa94d63eb5ee59b4eb66dbdeeaf86bb4d848359484d/openresponses_types-2.3.0.post1.tar.gz", hash = "sha256:11b8896d3621d2ac2439f6ff106f34ddcb1bbd517c317a6c852a9df2e98a0753", size = 19254, upload-time = "2026-01-22T20:02:03.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/5f/e16dad89ed24f586da5b01b9b206d3adbf21fe1af8e4dc55d5b93158fde6/openresponses_types-2.3.0.post1-py3-none-any.whl", hash = "sha256:88f6abcef9cad839203abff420dd080978bf6eb33cc06ddc5d78da4ccdba7613", size = 13847, upload-time = "2026-01-22T20:02:02.582Z" },
-]
-
-[[package]]
-name = "oss-harmony"
-version = "0.0.11"
-source = { git = "https://github.com/oss-harmony/harmony.git?rev=main#7d6d63a070e8f430768897ba4650373440cdf45e" }
-dependencies = [
-    { name = "pydantic" },
 ]
 
 [[package]]
@@ -647,8 +662,8 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "mlx-lm" },
+    { name = "openai-harmony" },
     { name = "openresponses-types" },
-    { name = "oss-harmony" },
     { name = "uvicorn" },
 ]
 
@@ -664,8 +679,8 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.119.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mlx-lm", specifier = "==0.31.0" },
+    { name = "openai-harmony", specifier = "==0.0.8" },
     { name = "openresponses-types" },
-    { name = "oss-harmony", git = "https://github.com/oss-harmony/harmony.git?rev=main" },
     { name = "uvicorn", specifier = "==0.38.0" },
 ]
 

--- a/tiles/Cargo.toml
+++ b/tiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiles"
-version = "0.4.10"
+version = "0.4.11-rc.1"
 edition = "2024"
 
 [dependencies]

--- a/tiles/Cargo.toml
+++ b/tiles/Cargo.toml
@@ -10,11 +10,11 @@ reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-tokio = { version = "1" , features = ["macros", "rt-multi-thread"]}
+tokio = { version = "1" , features = ["macros", "rt-multi-thread", "io-util"]}
 owo-colors = "4"
 futures-util = "0.3"
 hf-hub = {version = "0.4", features = ["tokio"]}
-rustyline = "17.0"
+rustyline = "18.0"
 toml = "1.0.3"
 semver = "1.0"
 rusqlite = { version = "0.38.0", features = ["bundled-sqlcipher-vendored-openssl"] }
@@ -37,6 +37,8 @@ hickory-resolver = "0.26.0"
 atrium-common = "0.1.4"
 atrium-api = "0.25.8"
 chacha20poly1305 = { version = "0.10" }
+libc = "0.2"
+ctrlc = "3.5.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tiles/src/daemon.rs
+++ b/tiles/src/daemon.rs
@@ -1,6 +1,7 @@
 //! The Demon that runs the core with his spear
 
 use std::{
+    os::unix::process::CommandExt,
     process::{Command, Stdio},
     sync::Arc,
     time::Duration,
@@ -98,13 +99,21 @@ async fn start_daemon(port: Option<u32>) -> Result<()> {
     } else {
         "tiles"
     };
-    let _process = Command::new(base_command)
-        .arg("daemon")
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout_log))
-        .stderr(Stdio::from(stderr_log))
-        .spawn()
-        .expect("Failed to start daemon");
+    let _process = unsafe {
+        Command::new(base_command)
+            .arg("daemon")
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout_log))
+            .stderr(Stdio::from(stderr_log))
+            .pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            })
+            .spawn()
+            .expect("Failed to start daemon")
+    };
 
     wait_until_server_is_up(port).await
 }

--- a/tiles/src/main.rs
+++ b/tiles/src/main.rs
@@ -438,7 +438,7 @@ fn print_help_for_command(command_path: &[String]) -> Result<(), Box<dyn Error>>
 fn build_logger() {
     if cfg!(debug_assertions) {
         env_logger::Builder::from_env(
-            env_logger::Env::default().default_filter_or("info,iroh=error,tracing=off"),
+            env_logger::Env::default().default_filter_or("warn,iroh=error,tracing=off"),
         )
         .init()
     } else {

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -268,14 +268,22 @@ pub async fn start_server_daemon() -> Result<()> {
         .open(data_dir.join("logs/server.err.log"))?;
     let server_path = server_dir.join("stack_export_prod/app-server/bin/python");
     server_dir.pop();
-    let child = Command::new(server_path)
-        .args(["-m", "server.main"])
-        .current_dir(server_dir)
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout_log))
-        .stderr(Stdio::from(stderr_log))
-        .spawn()
-        .expect("failed to start server");
+    let child = unsafe {
+        Command::new(server_path)
+            .args(["-m", "server.main"])
+            .current_dir(server_dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout_log))
+            .stderr(Stdio::from(stderr_log))
+            .pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            })
+            .spawn()
+            .expect("failed to start server")
+    };
 
     std::fs::write(pid_file, child.id().expect("Not child Id").to_string())
         .expect("Failed to write to pid file");
@@ -823,7 +831,9 @@ fn start_pi_rpc(model_name: &str, system_prompt: &str) -> Result<Child> {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .pre_exec(|| {
-                libc::setsid();
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
                 Ok(())
             })
             .spawn()

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -23,14 +23,17 @@ use rustyline::{Config, Editor, Helper};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::fs::{self, OpenOptions};
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdout, Command};
-use std::process::{ChildStdin, Stdio};
+use std::process::Stdio;
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use tilekit::modelfile::Modelfile;
 use tilekit::modelfile::Role;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::time::sleep;
 
 const MAX_LOAD_MODEL_RETRIES: u8 = 3;
@@ -274,8 +277,12 @@ pub async fn start_server_daemon() -> Result<()> {
         .spawn()
         .expect("failed to start server");
 
-    std::fs::write(pid_file, child.id().to_string()).expect("Failed to write to pid file");
-    println!("Server started with PID {}", child.id());
+    std::fs::write(pid_file, child.id().expect("Not child Id").to_string())
+        .expect("Failed to write to pid file");
+    println!(
+        "Server started with PID {}",
+        child.id().expect("No child Id")
+    );
     Ok(())
 }
 
@@ -295,7 +302,9 @@ pub async fn stop_server_daemon() -> Result<()> {
     Command::new("kill")
         .arg(pid.trim())
         .status()
+        .await
         .context("Failed to initiate kill commad")?;
+
     std::fs::remove_file(pid_file).context("Failed to removed pid file")?;
     println!("Server stopped.");
     Ok(())
@@ -348,6 +357,8 @@ enum CommandType {
     Resume,
     #[serde(rename = "set_thinking_level")]
     Reasoning,
+    #[serde(rename = "abort")]
+    Abort,
     #[serde(other)]
     Unknown,
 }
@@ -522,12 +533,20 @@ async fn start_repl(modelfile: &Modelfile, _run_args: &RunArgs, db_conn: &Dbconn
         .context("Failed to create editor")?;
     editor.set_helper(Some(TilesHinter));
 
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+
+    ctrlc::set_handler(move || {
+        r.store(false, std::sync::atomic::Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+
     // Setting up Pi rpc process handles
     let mut pi_process = start_pi_rpc(&modelname, &system_prompt)?;
     let pi_stdin = pi_process.stdin.as_mut().unwrap();
     let mut pi_stdout = pi_process.stdout.take().expect("stdout");
 
-    let pi_session_state = get_pi_state(pi_stdin, &mut pi_stdout)?;
+    let pi_session_state = get_pi_state(pi_stdin, &mut pi_stdout).await?;
     let mut repl_session = ReplSession::new(&pi_session_state);
 
     // The great REPL loop
@@ -558,7 +577,7 @@ async fn start_repl(modelfile: &Modelfile, _run_args: &RunArgs, db_conn: &Dbconn
                 break;
             }
             InputType::Prompt => {
-                handle_input_prompt(pi_stdin, &mut repl_session, &input)?;
+                handle_input_prompt(pi_stdin, &mut repl_session, &input).await?;
             }
             InputType::Command(cmd) => {
                 let res = handle_input_commands(cmd, &mut repl_session, db_conn, pi_stdin).await?;
@@ -570,9 +589,18 @@ async fn start_repl(modelfile: &Modelfile, _run_args: &RunArgs, db_conn: &Dbconn
         }
 
         // Reads the output from Pi and process and responds to the repl
-        let reader = BufReader::new(&mut pi_stdout);
-        for line in reader.lines() {
-            let line = line?;
+        let mut reader = BufReader::new(&mut pi_stdout).lines();
+
+        while let Some(line) = reader.next_line().await? {
+            if !running.load(std::sync::atomic::Ordering::SeqCst) {
+                info!("Ctrlc detected, aborting Pi ops");
+                let end_payload = json!({
+                    "type": "abort",
+                });
+                send_to_pi(pi_stdin, end_payload).await?;
+                running.store(true, std::sync::atomic::Ordering::SeqCst);
+                continue;
+            }
             let response: PiResponse =
                 serde_json::from_str(&line).context("Failed to parse Pi response")?;
             match response {
@@ -590,7 +618,8 @@ async fn start_repl(modelfile: &Modelfile, _run_args: &RunArgs, db_conn: &Dbconn
                         pi_stdin,
                         db_conn,
                         &current_user,
-                    )?;
+                    )
+                    .await?;
                     break;
                 }
                 PiResponse::TurnEnd(_turn_event) => {
@@ -602,13 +631,20 @@ async fn start_repl(modelfile: &Modelfile, _run_args: &RunArgs, db_conn: &Dbconn
                             CommandType::Unknown => {
                                 continue;
                             }
+                            CommandType::Abort => {
+                                info!("Abort command received");
+                                // continuing as we need to process the
+                                // agent_end event from Pi
+                                continue;
+                            }
                             _ => {
                                 process_command(
                                     response_msg,
                                     &mut repl_session,
                                     pi_stdin,
                                     &mut pi_stdout,
-                                )?;
+                                )
+                                .await?;
                                 break;
                             }
                         }
@@ -775,37 +811,42 @@ fn start_pi_rpc(model_name: &str, system_prompt: &str) -> Result<Child> {
 
     let pi_exec_path = tiles_lib_dir.join("pi/pi");
 
-    let pi_process = Command::new(pi_exec_path)
-        .arg("--mode")
-        .arg("rpc")
-        .arg("--append-system-prompt")
-        .arg(system_prompt)
-        .arg("--no-session")
-        .env("PI_CODING_AGENT_DIR", pi_agent_dir)
-        .env("PI_OFFLINE", "true")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("failed to run Pi");
-
+    let pi_process = unsafe {
+        Command::new(pi_exec_path)
+            .arg("--mode")
+            .arg("rpc")
+            .arg("--append-system-prompt")
+            .arg(system_prompt)
+            .arg("--no-session")
+            .env("PI_CODING_AGENT_DIR", pi_agent_dir)
+            .env("PI_OFFLINE", "true")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            })
+            .spawn()
+            .expect("failed to run Pi")
+    };
     Ok(pi_process)
 }
 
-fn send_to_pi(pi_child_stdin: &mut ChildStdin, payload_json: Value) -> Result<()> {
+async fn send_to_pi(pi_child_stdin: &mut ChildStdin, payload_json: Value) -> Result<()> {
     let payload_str = format!("{}\n", serde_json::to_string(&payload_json)?);
-    pi_child_stdin.write_all(payload_str.as_bytes())?;
-    pi_child_stdin.flush()?;
+    pi_child_stdin.write_all(payload_str.as_bytes()).await?;
+    pi_child_stdin.flush().await?;
     Ok(())
 }
 
-fn process_command(
+async fn process_command(
     response_msg: PiResponseMessage,
     repl_session: &mut ReplSession,
     pi_stdin: &mut ChildStdin,
     pi_stdout: &mut ChildStdout,
 ) -> Result<()> {
     if let CommandType::Reasoning = response_msg.command {
-        let state = get_pi_state(pi_stdin, pi_stdout)?;
+        let state = get_pi_state(pi_stdin, pi_stdout).await?;
         repl_session.reasoning = state
             .thinking_level
             .parse::<ReasoningEffort>()
@@ -1070,25 +1111,30 @@ fn handle_pi_message_update(msg_update: PiMessageUpdate) {
     }
 }
 
-fn get_pi_state(pi_stdin: &mut ChildStdin, pi_stdout: &mut ChildStdout) -> Result<GetStateData> {
+async fn get_pi_state(
+    pi_stdin: &mut ChildStdin,
+    pi_stdout: &mut ChildStdout,
+) -> Result<GetStateData> {
     let init_cmd_payload = json!({
         "type": "get_state",
     });
     send_to_pi(pi_stdin, init_cmd_payload)
+        .await
         .inspect_err(|_e| eprintln!("sending command to  pi failed"))?;
 
-    let mut pi_session_state = String::new();
-    let mut reader = BufReader::new(pi_stdout);
-    let _ = reader
-        .read_line(&mut pi_session_state)
-        .context("Failed reading pi session state")?;
-    let response: PiResponse = serde_json::from_str(&pi_session_state)?;
-    if let PiResponse::Response(msg) = response {
-        let state: GetStateData =
-            serde_json::from_value(msg.data.expect("get state parsing failed"))?;
-        Ok(state)
+    let reader = BufReader::new(pi_stdout);
+
+    if let Some(line) = reader.lines().next_line().await? {
+        let response: PiResponse = serde_json::from_str(&line)?;
+        if let PiResponse::Response(msg) = response {
+            let state: GetStateData =
+                serde_json::from_value(msg.data.expect("get state parsing failed"))?;
+            Ok(state)
+        } else {
+            Err(anyhow!("Failed to fetch initial state from Pi"))
+        }
     } else {
-        Err(anyhow!("Failed to fetch initial state from Pi"))
+        Err(anyhow!("Failed to fetch session_id from Pi"))
     }
 }
 
@@ -1097,8 +1143,8 @@ async fn handle_repl_exit(pi_stdin: &mut ChildStdin) -> Result<()> {
         "type": "abort",
     });
     let payload_str = format!("{}\n", serde_json::to_string(&end_payload)?);
-    pi_stdin.write_all(payload_str.as_bytes())?;
-    pi_stdin.flush()?;
+    pi_stdin.write_all(payload_str.as_bytes()).await?;
+    pi_stdin.flush().await?;
     println!("Exiting interactive mode");
     if !cfg!(debug_assertions) {
         let _res = stop_server_daemon().await;
@@ -1106,7 +1152,7 @@ async fn handle_repl_exit(pi_stdin: &mut ChildStdin) -> Result<()> {
     Ok(())
 }
 
-fn handle_input_prompt(
+async fn handle_input_prompt(
     pi_stdin: &mut ChildStdin,
     repl_session: &mut ReplSession,
     input: &str,
@@ -1126,7 +1172,7 @@ fn handle_input_prompt(
         "type": "prompt",
         "message": final_input
     });
-    send_to_pi(pi_stdin, payload)
+    send_to_pi(pi_stdin, payload).await
 }
 
 async fn handle_input_commands(
@@ -1170,18 +1216,19 @@ async fn handle_input_commands(
             InputCommandResponse::ProcessNextInput
         }
         CommandType::Reasoning => {
-            if let Err(err) = set_reasoning_effort(pi_stdin, &args) {
+            if let Err(err) = set_reasoning_effort(pi_stdin, &args).await {
                 println!("Failed to set reasoning effort due to {}", err);
                 InputCommandResponse::ProcessNextInput
             } else {
                 InputCommandResponse::WaitForNextLine
             }
         }
+        _ => InputCommandResponse::ProcessNextInput,
     };
     Ok(res)
 }
 
-fn process_pi_agent_end_event(
+async fn process_pi_agent_end_event(
     repl_session: &mut ReplSession,
     agent_end_event: PiAgentEndEvent,
     pi_stdin: &mut ChildStdin,
@@ -1198,7 +1245,7 @@ fn process_pi_agent_end_event(
         let payload = json!({
             "type": "abort"
         });
-        send_to_pi(pi_stdin, payload)?;
+        send_to_pi(pi_stdin, payload).await?;
         println!("An issue occurred, please try again!");
     }
 
@@ -1278,7 +1325,7 @@ fn get_pi_msg_content(msgs: Vec<PiMsgContent>) -> String {
     content.join("\n")
 }
 
-fn set_reasoning_effort(pi_stdin: &mut ChildStdin, args: &[&str]) -> Result<()> {
+async fn set_reasoning_effort(pi_stdin: &mut ChildStdin, args: &[&str]) -> Result<()> {
     let args = if let Some((_main_command, sub_commands)) = args.split_first() {
         sub_commands
     } else {
@@ -1300,7 +1347,7 @@ fn set_reasoning_effort(pi_stdin: &mut ChildStdin, args: &[&str]) -> Result<()> 
         "level": &effort_str
     });
 
-    send_to_pi(pi_stdin, pi_cmd)
+    send_to_pi(pi_stdin, pi_cmd).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- moved Pi to a different process group from its parent Tiles
- Upgraded rustyline lib to 18.0, as prev version was masking the SIGINT, even when not in readmode
- Using ctrlc lib to handle SIGINT
- Refactored repl loop to be async (sync version wont respond the SIGINT)
- Gracefull aborting Pi on SIGINT
- Only emitting toolcall events if there is non-empty tool name