### PR TITLE
fix: repl should close the inference, if value not yet in config

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ENV="prod" # prod is another env, try taking it from github env
 REPO="tilesprivacy/tiles"
 
-VERSION="0.4.10"
+VERSION="0.4.11"
 
 INSTALL_DIR="/usr/local/bin"           # CLI install location
 

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -1159,11 +1159,16 @@ async fn handle_repl_exit(pi_stdin: &mut ChildStdin) -> Result<()> {
     pi_stdin.write_all(payload_str.as_bytes()).await?;
     pi_stdin.flush().await?;
     println!("Exiting interactive mode");
-    if !cfg!(debug_assertions)
-        && let Some(inference_config) = get_inference_config()?
-        && !inference_config.daemon
-    {
-        let _res = stop_server_daemon().await;
+    if !cfg!(debug_assertions) {
+        match get_inference_config()? {
+            Some(inference_config) if !inference_config.daemon => {
+                let _res = stop_server_daemon().await;
+            }
+            None => {
+                let _res = stop_server_daemon().await;
+            }
+            _ => (),
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
- By default the inference valuie will not be config.toml. So we treat it as a daemon false, and closing repl shouldnt let the inference up