### PR TITLE
Decouple Pi agent from repl

### DIFF
--- a/scripts/build_with_pi_dev.sh
+++ b/scripts/build_with_pi_dev.sh
@@ -5,7 +5,7 @@ rm -rf .tiles_dev/tiles/pi
 
 VERSION=$(grep '^pi' toolchain.toml | head -1 | awk -F'"' '{print $2}')
 
-TAR_URL="https://github.com/badlogic/pi-mono/releases/download/${VERSION}/pi-darwin-arm64.tar.gz"
+
 
 # Detect OS
 case "$(uname -s)" in
@@ -23,6 +23,8 @@ esac
 
 PLATFORM="${OS}-${ARCH}"
 TARBALL="pi-${PLATFORM}.tar.gz"
+
+TAR_URL="https://github.com/badlogic/pi-mono/releases/download/${VERSION}/${TARBALL}"
 
 # TAR_URL="https://github.com/tilesprivacy/tiles-pi/releases/download/${VERSION}/${TARBALL}"
 

--- a/scripts/build_with_pi_dev.sh
+++ b/scripts/build_with_pi_dev.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 rm -rf .tiles_dev/tiles/pi
 
-VERSION=$(grep '^tiles-pi' toolchain.toml | head -1 | awk -F'"' '{print $2}')
+VERSION=$(grep '^pi' toolchain.toml | head -1 | awk -F'"' '{print $2}')
 
-# TAR_URL="https://github.com/badlogic/pi-mono/releases/download/${VERSION}/pi-darwin-arm64.tar.gz"
+TAR_URL="https://github.com/badlogic/pi-mono/releases/download/${VERSION}/pi-darwin-arm64.tar.gz"
 
 # Detect OS
 case "$(uname -s)" in
@@ -24,7 +24,7 @@ esac
 PLATFORM="${OS}-${ARCH}"
 TARBALL="pi-${PLATFORM}.tar.gz"
 
-TAR_URL="https://github.com/tilesprivacy/tiles-pi/releases/download/${VERSION}/${TARBALL}"
+# TAR_URL="https://github.com/tilesprivacy/tiles-pi/releases/download/${VERSION}/${TARBALL}"
 
 echo "Downloading Pi ${VERSION} for ${PLATFORM}..."
 curl -fL -o "$TARBALL" "$TAR_URL"

--- a/tiles/src/core/agent/mod.rs
+++ b/tiles/src/core/agent/mod.rs
@@ -1,0 +1,2 @@
+pub mod pi;
+pub mod types;

--- a/tiles/src/core/agent/pi.rs
+++ b/tiles/src/core/agent/pi.rs
@@ -1,0 +1,139 @@
+//! Module that deals with Pi
+use crate::core::agent::types::{GetStateData, PiResponse};
+use crate::utils::config::{
+    ConfigProvider, DefaultProvider, create_pi_provider_config, handle_pi_settings_config,
+};
+use anyhow::{Context, Result, anyhow};
+use nix::unistd::setsid;
+use serde_json::{Value, json};
+use std::{fs, process::Stdio};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+
+pub struct PiAgent {
+    #[allow(dead_code)]
+    // we will later use dead_code
+    process: Child,
+    writer: PiWriter,
+    reader: PiReader,
+}
+
+pub struct PiWriter {
+    stdin: ChildStdin,
+}
+
+pub struct PiReader {
+    lines: Lines<BufReader<ChildStdout>>,
+}
+
+pub fn new(model_name: &str, system_prompt: &str, port: u32) -> Result<PiAgent> {
+    let tiles_lib_dir = DefaultProvider.get_lib_dir()?;
+    let user_data_dir = DefaultProvider.get_user_data_dir()?;
+    let pi_agent_dir = user_data_dir.join("pi/agent/");
+    std::fs::create_dir_all(&pi_agent_dir).context("Failed to create Pi agent directory")?;
+
+    let provider_config_file_path = pi_agent_dir.join("models.json");
+    let endpoint_url = format!("http://127.0.0.1:{}/v1", port);
+    let model_config = create_pi_provider_config(model_name, &endpoint_url)?;
+
+    fs::write(provider_config_file_path, model_config)?;
+
+    let settings_file_path = pi_agent_dir.join("settings.json");
+    handle_pi_settings_config(&settings_file_path)?;
+
+    let pi_exec_path = tiles_lib_dir.join("pi/pi");
+
+    let mut pi_process = unsafe {
+        Command::new(pi_exec_path)
+            .arg("--mode")
+            .arg("rpc")
+            .arg("--append-system-prompt")
+            .arg(system_prompt)
+            .arg("--no-session")
+            .env("PI_CODING_AGENT_DIR", pi_agent_dir)
+            .env("PI_OFFLINE", "true")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .pre_exec(|| {
+                if let Err(err) = setsid() {
+                    Err(Into::into(err))
+                } else {
+                    Ok(())
+                }
+            })
+            .spawn()
+            .expect("failed to run Pi")
+    };
+
+    //TODO: Remove the unwrap
+    let pi_stdin = pi_process.stdin.take().unwrap();
+    let pi_stdout = pi_process.stdout.take().expect("stdout");
+
+    Ok(PiAgent {
+        process: pi_process,
+        reader: PiReader {
+            lines: BufReader::new(pi_stdout).lines(),
+        },
+        writer: PiWriter { stdin: pi_stdin },
+    })
+}
+pub async fn handle_graceful_exit(writer: &mut PiWriter) -> Result<()> {
+    let end_payload = json!({
+        "type": "abort",
+    });
+    writer.send_to_pi(end_payload).await
+}
+
+//TODO: we should make the member function names pi agnostic..
+impl PiAgent {
+    pub fn split(self) -> (PiReader, PiWriter) {
+        (self.reader, self.writer)
+    }
+}
+
+//TODO: move this to an associative function
+
+impl PiWriter {
+    pub async fn send_to_pi(&mut self, payload_json: Value) -> Result<()> {
+        let payload_str = format!("{}\n", serde_json::to_string(&payload_json)?);
+        self.stdin
+            .write_all(payload_str.as_bytes())
+            .await
+            .context("Failed to send to Pi's stdin")?;
+        self.stdin
+            .flush()
+            .await
+            .context("Failed to flush Pi stdin")?;
+        Ok(())
+    }
+}
+
+impl PiReader {
+    pub async fn get_pi_state(&mut self, writer: &mut PiWriter) -> Result<GetStateData> {
+        let init_cmd_payload = json!({
+            "type": "get_state",
+        });
+
+        writer
+            .send_to_pi(init_cmd_payload)
+            .await
+            .inspect_err(|_e| eprintln!("sending command to  pi failed"))?;
+
+        if let Some(line) = self.lines.next_line().await? {
+            let response: PiResponse = serde_json::from_str(&line)?;
+            if let PiResponse::Response(msg) = response {
+                let state: GetStateData =
+                    serde_json::from_value(msg.data.expect("get state parsing failed"))?;
+                Ok(state)
+            } else {
+                Err(anyhow!("Failed to fetch initial state from Pi"))
+            }
+        } else {
+            Err(anyhow!("Failed to fetch session_id from Pi"))
+        }
+    }
+
+    pub async fn next_line(&mut self) -> std::result::Result<Option<String>, std::io::Error> {
+        self.lines.next_line().await
+    }
+}

--- a/tiles/src/core/agent/pi.rs
+++ b/tiles/src/core/agent/pi.rs
@@ -24,6 +24,8 @@ pub struct PiReader {
     lines: Lines<BufReader<ChildStdout>>,
 }
 
+//TODO: check if we need a use case of kill_on_drop(true)
+/// Creates a Pi Agent instance with writer and reader for comms with Pi
 pub fn new(model_name: &str, system_prompt: &str, port: u32) -> Result<PiAgent> {
     let tiles_lib_dir = DefaultProvider.get_lib_dir()?;
     let user_data_dir = DefaultProvider.get_user_data_dir()?;
@@ -59,13 +61,18 @@ pub fn new(model_name: &str, system_prompt: &str, port: u32) -> Result<PiAgent> 
                     Ok(())
                 }
             })
-            .spawn()
-            .expect("failed to run Pi")
+            .spawn()?
     };
 
-    //TODO: Remove the unwrap
-    let pi_stdin = pi_process.stdin.take().unwrap();
-    let pi_stdout = pi_process.stdout.take().expect("stdout");
+    let pi_stdin = pi_process
+        .stdin
+        .take()
+        .ok_or(anyhow!("Failed to get pi stdin"))?;
+
+    let pi_stdout = pi_process
+        .stdout
+        .take()
+        .ok_or(anyhow!("Failed to get pi stdout"))?;
 
     Ok(PiAgent {
         process: pi_process,
@@ -75,6 +82,9 @@ pub fn new(model_name: &str, system_prompt: &str, port: u32) -> Result<PiAgent> 
         writer: PiWriter { stdin: pi_stdin },
     })
 }
+
+/// Gracefully exit an ongoing Pi agent session.
+/// NOTE: This doesnot kill Pi background process
 pub async fn handle_graceful_exit(writer: &mut PiWriter) -> Result<()> {
     let end_payload = json!({
         "type": "abort",
@@ -82,31 +92,26 @@ pub async fn handle_graceful_exit(writer: &mut PiWriter) -> Result<()> {
     writer.send_to_pi(end_payload).await
 }
 
-//TODO: we should make the member function names pi agnostic..
 impl PiAgent {
     pub fn split(self) -> (Child, PiReader, PiWriter) {
         (self.process, self.reader, self.writer)
     }
 }
 
-//TODO: move this to an associative function
-
 impl PiWriter {
+    /// Send requests to Pi in `json!` format
     pub async fn send_to_pi(&mut self, payload_json: Value) -> Result<()> {
         let payload_str = format!("{}\n", serde_json::to_string(&payload_json)?);
         self.stdin
             .write_all(payload_str.as_bytes())
             .await
             .context("Failed to send to Pi's stdin")?;
-        self.stdin
-            .flush()
-            .await
-            .context("Failed to flush Pi stdin")?;
-        Ok(())
+        self.stdin.flush().await.context("Failed to flush Pi stdin")
     }
 }
 
 impl PiReader {
+    /// Gets current Pi State
     pub async fn get_pi_state(&mut self, writer: &mut PiWriter) -> Result<GetStateData> {
         let init_cmd_payload = json!({
             "type": "get_state",
@@ -131,6 +136,7 @@ impl PiReader {
         }
     }
 
+    /// Reads the next line for Pi's stdout
     pub async fn next_line(&mut self) -> std::result::Result<Option<String>, std::io::Error> {
         self.lines.next_line().await
     }

--- a/tiles/src/core/agent/pi.rs
+++ b/tiles/src/core/agent/pi.rs
@@ -11,11 +11,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 
 pub struct PiAgent {
-    #[allow(dead_code)]
-    // we will later use dead_code
-    process: Child,
-    writer: PiWriter,
-    reader: PiReader,
+    pub process: Child,
+    pub writer: PiWriter,
+    pub reader: PiReader,
 }
 
 pub struct PiWriter {
@@ -86,8 +84,8 @@ pub async fn handle_graceful_exit(writer: &mut PiWriter) -> Result<()> {
 
 //TODO: we should make the member function names pi agnostic..
 impl PiAgent {
-    pub fn split(self) -> (PiReader, PiWriter) {
-        (self.reader, self.writer)
+    pub fn split(self) -> (Child, PiReader, PiWriter) {
+        (self.process, self.reader, self.writer)
     }
 }
 

--- a/tiles/src/core/agent/types.rs
+++ b/tiles/src/core/agent/types.rs
@@ -3,6 +3,9 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use tilekit::modelfile::Role;
+
+//TODO: Change this into harness agnostic types in the names
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum PiResponse {

--- a/tiles/src/core/agent/types.rs
+++ b/tiles/src/core/agent/types.rs
@@ -1,0 +1,200 @@
+//! Types we use for Agent communication
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use tilekit::modelfile::Role;
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum PiResponse {
+    #[serde(rename = "response")]
+    Response(PiResponseMessage),
+    #[serde(rename = "agent_start")]
+    AgentStart,
+    #[serde(rename = "message_update")]
+    MessageUpdate(PiMessageUpdate),
+    #[serde(rename = "agent_end")]
+    AgentEnd(PiAgentEndEvent),
+    #[serde(rename = "turn_end")]
+    TurnEnd(PiTurnEndEvent),
+    #[serde[other]]
+    Unknown,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiAgentEndEvent {
+    pub messages: Vec<PiMsgEvent>,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GetStateData {
+    pub model: PiModelInfo,
+    #[serde(rename = "thinkingLevel")]
+    pub thinking_level: String,
+    #[serde(rename = "isStreaming")]
+    pub is_streaming: bool,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiModelInfo {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiSettings {
+    pub compaction: Option<CompactionSettings>,
+    #[serde(rename = "defaultThinkingLevel")]
+    pub default_thinking_level: Option<ReasoningEffort>,
+}
+
+impl Default for PiSettings {
+    fn default() -> Self {
+        PiSettings {
+            compaction: Some(CompactionSettings { enabled: false }),
+            default_thinking_level: Some(ReasoningEffort::Medium),
+        }
+    }
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd)]
+pub struct CompactionSettings {
+    pub enabled: bool,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiMessageUpdate {
+    #[serde(rename = "assistantMessageEvent")]
+    pub assistant_message_event: PiAsstTextMsg,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiAsstTextMsg {
+    pub r#type: AsstMsgEventType,
+    pub delta: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum AsstMsgEventType {
+    #[serde(rename = "start")]
+    Start,
+    #[serde(rename = "text_start")]
+    TextStart,
+    #[serde(rename = "text_delta")]
+    TextDelta,
+    #[serde(rename = "text_end")]
+    TextEnd,
+    #[serde(rename = "thinking_start")]
+    ThinkingStart,
+    #[serde(rename = "thinking_delta")]
+    ThinkingDelta,
+    #[serde(rename = "thinking_end")]
+    ThinkingEnd,
+    #[serde(rename = "toolcall_start")]
+    ToolcallStart,
+    #[serde(rename = "toolcall_delta")]
+    ToolcallDelta,
+    #[serde(rename = "toolcall_end")]
+    ToolcallEnd,
+    #[serde(rename = "done")]
+    Done,
+    #[serde(rename = "error")]
+    Error,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiResponseMessage {
+    pub command: CommandType,
+    pub success: bool,
+    pub data: Option<Value>,
+}
+#[derive(Deserialize, Serialize, Debug)]
+pub enum CommandType {
+    #[serde(rename = "status")]
+    Status,
+    #[serde(rename = "share")]
+    Share,
+    #[serde(rename = "sessions")]
+    Sessions,
+    #[serde(rename = "resume")]
+    Resume,
+    #[serde(rename = "reasoning")]
+    Reasoning,
+    #[serde(rename = "set_thinking_level")]
+    SetThinkingLevel,
+    #[serde(rename = "abort")]
+    Abort,
+    #[serde(rename = "skills")]
+    Skills,
+    #[serde(rename = "get_commands")]
+    GetCommands,
+    #[serde(other)]
+    Unknown,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Commands {
+    pub name: String,
+    pub description: String,
+    pub source: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiTurnEndEvent {
+    message: PiTurnEndEventMsg,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PiTurnEndEventMsg {
+    role: String,
+    content: Vec<PiMsgContent>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PiMsgEvent {
+    pub role: Role,
+    pub content: Vec<PiMsgContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "stopReason")]
+    pub stop_reason: Option<String>,
+    pub timestamp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "toolName")]
+    pub tool_name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PiMsgContent {
+    pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, deserialize_with = "map_to_option_string")]
+    pub arguments: Option<String>,
+    // Tool name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+fn map_to_option_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<Value>::deserialize(deserializer)?;
+
+    match opt {
+        Some(Value::String(s)) => Ok(Some(s)),
+        Some(Value::Object(map)) => serde_json::to_string(&map)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        Some(other) => Ok(Some(other.to_string())),
+        None => Ok(None),
+    }
+}
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub enum ReasoningEffort {
+    #[serde(rename = "high")]
+    High,
+    #[serde(rename = "medium")]
+    Medium,
+    #[serde(rename = "low")]
+    Low,
+}

--- a/tiles/src/core/mod.rs
+++ b/tiles/src/core/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 pub mod account;
+pub mod agent;
 pub mod chats;
 pub mod health;
 pub mod network;

--- a/tiles/src/daemon.rs
+++ b/tiles/src/daemon.rs
@@ -28,6 +28,7 @@ use tokio::sync::oneshot::{self, Receiver, Sender};
 use crate::{
     core::{
         account::{atproto::AtCallbackParams, local::get_current_user},
+        agent::pi::{PiReader, PiWriter},
         network::{self, create_endpoint, share},
         storage::db::get_db_conn,
     },
@@ -37,9 +38,12 @@ use crate::{
 struct AppState {
     pub shutdown_sender: Mutex<Option<oneshot::Sender<bool>>>,
     pub vsn: String,
+    //TODO: refactor the remote infy related fields
     pub remote_ticket: Mutex<Option<String>>,
     pub remote_running: Mutex<bool>,
     pub remote_shutdown_sender: Mutex<Option<oneshot::Sender<bool>>>,
+    pub agent_reader: Mutex<Option<PiReader>>,
+    pub agent_writer: Mutex<Option<PiWriter>>,
 }
 
 struct InternalAppState {
@@ -147,12 +151,18 @@ pub async fn start_server(port: Option<u32>) -> Result<()> {
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<bool>();
 
+    // let pi_agent = pi::new(&modelname, &system_prompt, port)?;
+
+    // let (mut agent_reader, mut agent_writer) = pi_agent.split();
+
     let state = AppState {
         shutdown_sender: Mutex::new(Some(shutdown_tx)),
         vsn: env!("CARGO_PKG_VERSION").to_owned(),
         remote_ticket: Mutex::new(None),
         remote_shutdown_sender: Mutex::new(None),
         remote_running: Mutex::new(false),
+        agent_reader: Mutex::new(None),
+        agent_writer: Mutex::new(None),
     };
 
     let shared_state = Arc::new(state);
@@ -165,6 +175,9 @@ pub async fn start_server(port: Option<u32>) -> Result<()> {
         .route("/remote-unshare", get(unshare_remote_inference))
         .route("/remote-status", get(show_remote_status))
         .route("/connect-remote", get(connect_remote_inference))
+        .route("/agent/start", get(start_agent))
+        // .route("/agent/stop", post(stop_agent))
+        // .route("/agent/status", get(get_agent_status))
         .with_state(shared_state);
 
     let addr = format!("127.0.0.1:{}", dyn_port);
@@ -471,6 +484,20 @@ pub async fn connect_remote(ticket: &str) -> Result<()> {
         Ok(_response) => Ok(()),
     }
 }
+
+async fn start_agent(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
+    // let reader = state.agent_reader.lock().unwrap();
+
+    //     if let Some(reader) = *() {
+    //     Ok(String::from("agent already up"))
+    // } else {
+    //     Ok(String::from("Started agent"))
+    // }
+    //
+
+    todo!()
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;

--- a/tiles/src/daemon/agent.rs
+++ b/tiles/src/daemon/agent.rs
@@ -2,74 +2,79 @@
 
 use std::sync::Arc;
 
-use axum::{Router, extract::State, routing::get};
+use axum::{Router, extract::State, response::IntoResponse, routing::get};
 use axum_macros::debug_handler;
-use reqwest::StatusCode;
+use serde_json::json;
 
 use crate::{
-    core::agent::pi::{self, PiAgent},
-    daemon::AppState,
+    core::agent::pi::{self},
+    daemon::{ApiResponse, AppError, AppState},
     repl::get_default_modelfile,
     utils::config::PY_PORT,
 };
 
 pub fn agent_router() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/agent/start", get(start_agent))
-        .route("/agent/stop", get(stop_agent))
-        .route("/agent/status", get(agent_status))
+        .route("/v1/tilekit/agent/start", get(start_agent))
+        .route("/v1/tilekit/agent/end_session", get(end_current_session))
+        .route("/v1/tilekit/agent/status", get(agent_status))
 }
 
-async fn start_agent(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
+async fn start_agent(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
     let modelfile_path =
-        get_default_modelfile(false).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let default_modelfile = tilekit::modelfile::parse_from_file(
-        modelfile_path
-            .to_str()
-            .expect("default_modelfile_path: Failed PathBuf to str"),
-    )
-    .map_err(|_| StatusCode::INSUFFICIENT_STORAGE)?;
+        get_default_modelfile(false).map_err(|e| AppError::ModelFileNotFound(e.to_string()))?;
+    let default_modelfile = tilekit::modelfile::parse_from_file(&modelfile_path.to_string_lossy())
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
 
     let modelname = default_modelfile
         .from
         .clone()
-        .ok_or_else(|| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .expect("failed to take modelfile from Option");
 
     let system_prompt = default_modelfile.system.clone().unwrap_or("".to_owned());
 
-    let pi_agent = pi::new(&modelname, &system_prompt, PY_PORT)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
     let mut agent = state.agent.lock().await;
     if agent.is_some() {
-        Ok(String::from("agent already up"))
+        Ok(ApiResponse::success(
+            json!({"message": "Agent already started"}),
+        ))
     } else {
+        let pi_agent = pi::new(&modelname, &system_prompt, PY_PORT)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
         *agent = Some(pi_agent);
-        Ok(String::from("Started agent"))
+        Ok(ApiResponse::success(json!({"message": "started agent"})))
     }
 }
 
 #[debug_handler]
-async fn stop_agent(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
+async fn end_current_session(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
     let mut agent = state.agent.lock().await;
-    let agent = agent.as_mut().unwrap();
+    let agent = agent.as_mut().ok_or(AppError::InternalServerError(
+        "Failed to get a mutable agent instance".to_string(),
+    ))?;
     pi::handle_graceful_exit(&mut agent.writer)
         .await
-        .map_err(|_| StatusCode::METHOD_NOT_ALLOWED)?;
-    Ok(String::from("Stopped agent"))
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+    Ok(ApiResponse::success(
+        json!({"message": "Successfully ended current session"}),
+    ))
 }
 
-async fn agent_status(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
+// TODO: add timeout to apis
+async fn agent_status(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
     let mut agent = state.agent.lock().await;
-    let agent = agent.as_mut().unwrap();
+    let agent = agent.as_mut().ok_or(AppError::InternalServerError(
+        "Failed to get a mutable agent instance".to_string(),
+    ))?;
 
     let state = agent
         .reader
         .get_pi_state(&mut agent.writer)
         .await
-        .map_err(|_| StatusCode::FAILED_DEPENDENCY)?;
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
 
-    let state_str = format!("{}", serde_json::to_string(&state).unwrap());
-
-    Ok(state_str)
+    Ok(ApiResponse::success(serde_json::to_value(state).unwrap()))
 }

--- a/tiles/src/daemon/agent.rs
+++ b/tiles/src/daemon/agent.rs
@@ -1,0 +1,75 @@
+//! APIs for communication with Agent harness (Pi)
+
+use std::sync::Arc;
+
+use axum::{Router, extract::State, routing::get};
+use axum_macros::debug_handler;
+use reqwest::StatusCode;
+
+use crate::{
+    core::agent::pi::{self, PiAgent},
+    daemon::AppState,
+    repl::get_default_modelfile,
+    utils::config::PY_PORT,
+};
+
+pub fn agent_router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/agent/start", get(start_agent))
+        .route("/agent/stop", get(stop_agent))
+        .route("/agent/status", get(agent_status))
+}
+
+async fn start_agent(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
+    let modelfile_path =
+        get_default_modelfile(false).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let default_modelfile = tilekit::modelfile::parse_from_file(
+        modelfile_path
+            .to_str()
+            .expect("default_modelfile_path: Failed PathBuf to str"),
+    )
+    .map_err(|_| StatusCode::INSUFFICIENT_STORAGE)?;
+
+    let modelname = default_modelfile
+        .from
+        .clone()
+        .ok_or_else(|| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let system_prompt = default_modelfile.system.clone().unwrap_or("".to_owned());
+
+    let pi_agent = pi::new(&modelname, &system_prompt, PY_PORT)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut agent = state.agent.lock().await;
+    if agent.is_some() {
+        Ok(String::from("agent already up"))
+    } else {
+        *agent = Some(pi_agent);
+        Ok(String::from("Started agent"))
+    }
+}
+
+#[debug_handler]
+async fn stop_agent(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
+    let mut agent = state.agent.lock().await;
+    let agent = agent.as_mut().unwrap();
+    pi::handle_graceful_exit(&mut agent.writer)
+        .await
+        .map_err(|_| StatusCode::METHOD_NOT_ALLOWED)?;
+    Ok(String::from("Stopped agent"))
+}
+
+async fn agent_status(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
+    let mut agent = state.agent.lock().await;
+    let agent = agent.as_mut().unwrap();
+
+    let state = agent
+        .reader
+        .get_pi_state(&mut agent.writer)
+        .await
+        .map_err(|_| StatusCode::FAILED_DEPENDENCY)?;
+
+    let state_str = format!("{}", serde_json::to_string(&state).unwrap());
+
+    Ok(state_str)
+}

--- a/tiles/src/daemon/mod.rs
+++ b/tiles/src/daemon/mod.rs
@@ -8,6 +8,7 @@ use std::{
     time::Duration,
 };
 
+use crate::{core::agent::pi::PiAgent, daemon::agent::agent_router};
 use anyhow::{Result, anyhow};
 use axum::{
     Router,
@@ -23,27 +24,26 @@ use reqwest::Client;
 use semver::Version;
 use std::fs::OpenOptions;
 use std::sync::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::oneshot::{self, Receiver, Sender};
-
+pub mod agent;
 use crate::{
     core::{
         account::{atproto::AtCallbackParams, local::get_current_user},
-        agent::pi::{PiReader, PiWriter},
         network::{self, create_endpoint, share},
         storage::db::get_db_conn,
     },
     utils::config::{ConfigProvider, DefaultProvider, get_config_json, get_model_cache},
 };
 
-struct AppState {
+pub struct AppState {
     pub shutdown_sender: Mutex<Option<oneshot::Sender<bool>>>,
     pub vsn: String,
     //TODO: refactor the remote infy related fields
     pub remote_ticket: Mutex<Option<String>>,
     pub remote_running: Mutex<bool>,
     pub remote_shutdown_sender: Mutex<Option<oneshot::Sender<bool>>>,
-    pub agent_reader: Mutex<Option<PiReader>>,
-    pub agent_writer: Mutex<Option<PiWriter>>,
+    pub agent: AsyncMutex<Option<PiAgent>>,
 }
 
 struct InternalAppState {
@@ -151,18 +151,13 @@ pub async fn start_server(port: Option<u32>) -> Result<()> {
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<bool>();
 
-    // let pi_agent = pi::new(&modelname, &system_prompt, port)?;
-
-    // let (mut agent_reader, mut agent_writer) = pi_agent.split();
-
     let state = AppState {
         shutdown_sender: Mutex::new(Some(shutdown_tx)),
         vsn: env!("CARGO_PKG_VERSION").to_owned(),
         remote_ticket: Mutex::new(None),
         remote_shutdown_sender: Mutex::new(None),
         remote_running: Mutex::new(false),
-        agent_reader: Mutex::new(None),
-        agent_writer: Mutex::new(None),
+        agent: None.into(),
     };
 
     let shared_state = Arc::new(state);
@@ -175,9 +170,7 @@ pub async fn start_server(port: Option<u32>) -> Result<()> {
         .route("/remote-unshare", get(unshare_remote_inference))
         .route("/remote-status", get(show_remote_status))
         .route("/connect-remote", get(connect_remote_inference))
-        .route("/agent/start", get(start_agent))
-        // .route("/agent/stop", post(stop_agent))
-        // .route("/agent/status", get(get_agent_status))
+        .merge(agent_router())
         .with_state(shared_state);
 
     let addr = format!("127.0.0.1:{}", dyn_port);
@@ -483,19 +476,6 @@ pub async fn connect_remote(ticket: &str) -> Result<()> {
         Err(err) => Err(anyhow!("Daemon remote connect failed due to {:?}", err)),
         Ok(_response) => Ok(()),
     }
-}
-
-async fn start_agent(State(state): State<Arc<AppState>>) -> Result<String, StatusCode> {
-    // let reader = state.agent_reader.lock().unwrap();
-
-    //     if let Some(reader) = *() {
-    //     Ok(String::from("agent already up"))
-    // } else {
-    //     Ok(String::from("Started agent"))
-    // }
-    //
-
-    todo!()
 }
 
 #[cfg(test)]

--- a/tiles/src/daemon/mod.rs
+++ b/tiles/src/daemon/mod.rs
@@ -11,9 +11,10 @@ use std::{
 use crate::{core::agent::pi::PiAgent, daemon::agent::agent_router};
 use anyhow::{Result, anyhow};
 use axum::{
-    Router,
+    Json, Router,
     extract::{Query, State},
     http::StatusCode,
+    response::IntoResponse,
     routing::get,
 };
 use axum_macros::debug_handler;
@@ -22,6 +23,8 @@ use log::info;
 use nix::unistd::setsid;
 use reqwest::Client;
 use semver::Version;
+use serde::Serialize;
+use serde_json::json;
 use std::fs::OpenOptions;
 use std::sync::Mutex;
 use tokio::sync::Mutex as AsyncMutex;
@@ -44,6 +47,41 @@ pub struct AppState {
     pub remote_running: Mutex<bool>,
     pub remote_shutdown_sender: Mutex<Option<oneshot::Sender<bool>>>,
     pub agent: AsyncMutex<Option<PiAgent>>,
+}
+
+pub enum AppError {
+    ModelFileNotFound(String),
+    InternalServerError(String),
+}
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        let (status, reason) = match self {
+            Self::ModelFileNotFound(e) => (StatusCode::NOT_FOUND, e),
+            Self::InternalServerError(e) => (StatusCode::INTERNAL_SERVER_ERROR, e),
+        };
+
+        let body = Json(json!({
+            "status": "failed",
+            "reason": reason
+        }));
+
+        (status, body).into_response()
+    }
+}
+
+#[derive(Serialize)]
+pub struct ApiResponse<T> {
+    status: String,
+    data: T,
+}
+
+impl<T: Serialize> ApiResponse<T> {
+    fn success(data: T) -> Json<Self> {
+        Json(Self {
+            status: "success".to_string(),
+            data,
+        })
+    }
 }
 
 struct InternalAppState {

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -1,6 +1,6 @@
 use crate::core::account::atproto::{fetch_logged_in_data, login, share_session};
 use crate::core::account::local::get_current_user;
-use crate::core::agent::pi::{PiAgent, PiReader, PiWriter};
+use crate::core::agent::pi::{PiAgent, PiWriter};
 use crate::core::agent::types::{
     CommandType, Commands, PiAgentEndEvent, PiMsgContent, PiResponse, PiResponseMessage,
     ReasoningEffort,

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -1,5 +1,11 @@
 use crate::core::account::atproto::{fetch_logged_in_data, login, share_session};
 use crate::core::account::local::get_current_user;
+use crate::core::agent::pi::{PiReader, PiWriter};
+use crate::core::agent::types::{
+    CommandType, Commands, PiAgentEndEvent, PiMsgContent, PiResponse, PiResponseMessage,
+    ReasoningEffort,
+};
+use crate::core::agent::{pi, types};
 use crate::core::chats::{
     Session, create_session, fetch_chats_by_session_id, fetch_session, fetch_sessions, save_chat,
     update_snapshot,
@@ -7,9 +13,8 @@ use crate::core::chats::{
 use crate::core::network;
 use crate::core::storage::db::Dbconn;
 use crate::utils::config::{
-    ConfigProvider, DefaultProvider, LlamaConfig, create_pi_provider_config, get_inference_config,
-    get_memory_path, get_model_cache, handle_pi_settings_config, update_current_model,
-    update_llama_config,
+    ConfigProvider, DefaultProvider, LlamaConfig, PY_PORT, REMOTE_BOUND_PORT, get_inference_config,
+    get_memory_path, get_model_cache, update_current_model, update_llama_config,
 };
 use crate::utils::hf_model_downloader::*;
 use crate::utils::lexicons::{SessionSnapshotRecord, Turn};
@@ -24,7 +29,7 @@ use rustyline::hint::Hinter;
 use rustyline::history::DefaultHistory;
 use rustyline::validate::Validator;
 use rustyline::{Config, Editor, Helper};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
@@ -37,8 +42,7 @@ use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use tilekit::modelfile::Modelfile;
 use tilekit::modelfile::Role;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::process::Command;
 use tokio::time::sleep;
 
 const MAX_LOAD_MODEL_RETRIES: u8 = 3;
@@ -82,183 +86,6 @@ pub struct ChatResponse {
     pub model_used: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "type")]
-enum PiResponse {
-    #[serde(rename = "response")]
-    Response(PiResponseMessage),
-    #[serde(rename = "agent_start")]
-    AgentStart,
-    #[serde(rename = "message_update")]
-    MessageUpdate(PiMessageUpdate),
-    #[serde(rename = "agent_end")]
-    AgentEnd(PiAgentEndEvent),
-    #[serde(rename = "turn_end")]
-    TurnEnd(PiTurnEndEvent),
-    #[serde[other]]
-    Unknown,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct GetStateData {
-    model: PiModelInfo,
-    #[serde(rename = "thinkingLevel")]
-    pub thinking_level: String,
-    #[serde(rename = "isStreaming")]
-    is_streaming: bool,
-    #[serde(rename = "sessionId")]
-    session_id: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct PiModelInfo {
-    id: String,
-    name: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PiSettings {
-    pub compaction: Option<CompactionSettings>,
-    #[serde(rename = "defaultThinkingLevel")]
-    pub default_thinking_level: Option<ReasoningEffort>,
-}
-
-impl Default for PiSettings {
-    fn default() -> Self {
-        PiSettings {
-            compaction: Some(CompactionSettings { enabled: false }),
-            default_thinking_level: Some(ReasoningEffort::Medium),
-        }
-    }
-}
-#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd)]
-pub struct CompactionSettings {
-    pub enabled: bool,
-}
-#[derive(Serialize, Deserialize, Debug)]
-struct PiMessageUpdate {
-    #[serde(rename = "assistantMessageEvent")]
-    assistant_message_event: PiAsstTextMsg,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct PiAsstTextMsg {
-    r#type: AsstMsgEventType,
-    delta: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct PiResponseMessage {
-    command: CommandType,
-    success: bool,
-    data: Option<Value>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Commands {
-    name: String,
-    description: String,
-    source: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct PiTurnEndEvent {
-    message: PiTurnEndEventMsg,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct PiTurnEndEventMsg {
-    role: String,
-    content: Vec<PiMsgContent>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PiMsgEvent {
-    role: Role,
-    content: Vec<PiMsgContent>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "stopReason")]
-    stop_reason: Option<String>,
-    timestamp: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "toolName")]
-    tool_name: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct PiMsgContent {
-    r#type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    thinking: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default, deserialize_with = "map_to_option_string")]
-    pub arguments: Option<String>,
-    // Tool name
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-}
-
-fn map_to_option_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let opt = Option::<Value>::deserialize(deserializer)?;
-
-    match opt {
-        Some(Value::String(s)) => Ok(Some(s)),
-        Some(Value::Object(map)) => serde_json::to_string(&map)
-            .map(Some)
-            .map_err(serde::de::Error::custom),
-        Some(other) => Ok(Some(other.to_string())),
-        None => Ok(None),
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct PiAgentEndEvent {
-    messages: Vec<PiMsgEvent>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-enum AsstMsgEventType {
-    #[serde(rename = "start")]
-    Start,
-    #[serde(rename = "text_start")]
-    TextStart,
-    #[serde(rename = "text_delta")]
-    TextDelta,
-    #[serde(rename = "text_end")]
-    TextEnd,
-    #[serde(rename = "thinking_start")]
-    ThinkingStart,
-    #[serde(rename = "thinking_delta")]
-    ThinkingDelta,
-    #[serde(rename = "thinking_end")]
-    ThinkingEnd,
-    #[serde(rename = "toolcall_start")]
-    ToolcallStart,
-    #[serde(rename = "toolcall_delta")]
-    ToolcallDelta,
-    #[serde(rename = "toolcall_end")]
-    ToolcallEnd,
-    #[serde(rename = "done")]
-    Done,
-    #[serde(rename = "error")]
-    Error,
-}
-
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub enum ReasoningEffort {
-    #[serde(rename = "high")]
-    High,
-    #[serde(rename = "medium")]
-    Medium,
-    #[serde(rename = "low")]
-    Low,
-}
-
 enum InputCommandResponse {
     WaitForNextLine,
     ProcessNextInput,
@@ -284,7 +111,6 @@ impl From<ReasoningEffort> for String {
         }
     }
 }
-const PY_PORT: u32 = 6969;
 
 pub async fn run(run_args: RunArgs, db_conn: &Dbconn) -> Result<()> {
     let (modelfile, default_modelfile) = if let Some(modelfile_str) = &run_args.modelfile_path {
@@ -431,30 +257,6 @@ enum InputType {
     Skill,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-enum CommandType {
-    #[serde(rename = "status")]
-    Status,
-    #[serde(rename = "share")]
-    Share,
-    #[serde(rename = "sessions")]
-    Sessions,
-    #[serde(rename = "resume")]
-    Resume,
-    #[serde(rename = "reasoning")]
-    Reasoning,
-    #[serde(rename = "set_thinking_level")]
-    SetThinkingLevel,
-    #[serde(rename = "abort")]
-    Abort,
-    #[serde(rename = "skills")]
-    Skills,
-    #[serde(rename = "get_commands")]
-    GetCommands,
-    #[serde(other)]
-    Unknown,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SharedSession {
     #[serde(rename = "$type")]
@@ -485,7 +287,7 @@ struct ReplSession {
 }
 
 impl ReplSession {
-    pub fn new(state: &GetStateData) -> Self {
+    pub fn new(state: &types::GetStateData) -> Self {
         ReplSession {
             session_id: state.session_id.clone(),
             resume_session_pending: false,
@@ -661,12 +463,17 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
     })
     .expect("Error setting Ctrl-C handler");
 
+    let port = if run_args.remote.is_none() {
+        PY_PORT
+    } else {
+        REMOTE_BOUND_PORT
+    };
     // Setting up Pi rpc process handles
-    let mut pi_process = start_pi_rpc(&modelname, &system_prompt, run_args.remote.clone())?;
-    let pi_stdin = pi_process.stdin.as_mut().unwrap();
-    let mut pi_stdout = pi_process.stdout.take().expect("stdout");
+    let pi_agent = pi::new(&modelname, &system_prompt, port)?;
 
-    let pi_session_state = get_pi_state(pi_stdin, &mut pi_stdout).await?;
+    let (mut agent_reader, mut agent_writer) = pi_agent.split();
+
+    let pi_session_state = agent_reader.get_pi_state(&mut agent_writer).await?;
     let mut repl_session = ReplSession::new(&pi_session_state);
 
     // The great REPL loop
@@ -676,7 +483,7 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
         let input = match readline {
             Ok(line) => line.trim().to_string(),
             Err(_) => {
-                handle_repl_exit(pi_stdin).await?;
+                handle_repl_exit(&mut agent_writer).await?;
                 break;
             }
         };
@@ -689,19 +496,20 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
         match handle_input(&input.to_lowercase()) {
             InputType::Skip => continue,
             InputType::Exit => {
-                handle_repl_exit(pi_stdin).await?;
+                handle_repl_exit(&mut agent_writer).await?;
                 break;
             }
             InputType::Prompt => {
-                handle_input_prompt(pi_stdin, &mut repl_session, &input).await?;
+                handle_input_prompt(&mut agent_writer, &mut repl_session, &input).await?;
             }
             InputType::Skill => {
                 let (_, skill_name) = input.split_at(1);
                 let skill_prompt = format!("/skill:{}", skill_name);
-                handle_input_prompt(pi_stdin, &mut repl_session, &skill_prompt).await?;
+                handle_input_prompt(&mut agent_writer, &mut repl_session, &skill_prompt).await?;
             }
             InputType::Command(cmd) => {
-                let res = handle_input_commands(cmd, &mut repl_session, db_conn, pi_stdin).await?;
+                let res = handle_input_commands(cmd, &mut repl_session, db_conn, &mut agent_writer)
+                    .await?;
 
                 if let InputCommandResponse::ProcessNextInput = res {
                     continue;
@@ -709,22 +517,22 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
             }
         }
 
-        // This is to prevent the session name being messeup if user starts
+        // This is to prevent the session name being messedup if user starts
         // with skills. Pi unfurls skills command to entire skill doc.So we
-        // cant put that as session name.
+        // can't put that as session name.
         if !repl_session.session_started {
             repl_session.session_snapshot.name = input.clone();
         };
-        // Reads the output from Pi and process and responds to the repl
-        let mut reader = BufReader::new(&mut pi_stdout).lines();
 
-        while let Some(line) = reader.next_line().await? {
+        // Reads the output from Pi and process and responds to the repl
+
+        while let Some(line) = agent_reader.next_line().await? {
             if !running.load(std::sync::atomic::Ordering::SeqCst) {
                 info!("Ctrlc detected, aborting Pi ops");
                 let end_payload = json!({
                     "type": "abort",
                 });
-                send_to_pi(pi_stdin, end_payload).await?;
+                agent_writer.send_to_pi(end_payload).await?;
                 running.store(true, std::sync::atomic::Ordering::SeqCst);
                 continue;
             }
@@ -742,7 +550,7 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
                     process_pi_agent_end_event(
                         &mut repl_session,
                         agent_end_event,
-                        pi_stdin,
+                        &mut agent_writer,
                         db_conn,
                         &current_user,
                     )
@@ -768,8 +576,8 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
                                 process_command(
                                     response_msg,
                                     &mut repl_session,
-                                    pi_stdin,
-                                    &mut pi_stdout,
+                                    &mut agent_reader,
+                                    &mut agent_writer,
                                 )
                                 .await?;
                                 break;
@@ -913,81 +721,15 @@ async fn download_model(model_name: &str) -> Result<()> {
     }
 }
 
-fn start_pi_rpc(model_name: &str, system_prompt: &str, remote: Option<String>) -> Result<Child> {
-    let tiles_lib_dir = DefaultProvider.get_lib_dir()?;
-    let user_data_dir = DefaultProvider.get_user_data_dir()?;
-    let pi_agent_dir = user_data_dir.join("pi/agent/");
-    std::fs::create_dir_all(&pi_agent_dir).context("Failed to create Pi agent directory")?;
-
-    let port = if remote.is_none() { PY_PORT } else { 9271 };
-    let provider_config_file_path = pi_agent_dir.join("models.json");
-    let endpoint_url = format!("http://127.0.0.1:{}/v1", port);
-    let model_config = create_pi_provider_config(model_name, &endpoint_url)?;
-
-    fs::write(provider_config_file_path, model_config)?;
-
-    let settings_file_path = pi_agent_dir.join("settings.json");
-    handle_pi_settings_config(&settings_file_path)?;
-    // For easy debugging Pi, when developing when needed we can directly call the
-    // local on-demand build pi binary and point local path
-    // assuming `tiles-pi` is cloned as a sibling in the same dir
-    // let pi_exec_path =
-    //  PathBuf::from("~/tiles-pi/packages/coding-agent/binaries/darwin-arm64/pi");
-    // For example:
-    // let pi_exec_path =
-    //     PathBuf::from("/Users/tiles/tiles-pi/packages/coding-agent/binaries/darwin-arm64/pi");
-    // On building binary locally, from tiles-pi root dir run
-    // `./scripts/build-binaries.sh --platform darwin-arm64`
-    // More platform flags can be seen in the `build-binaries.sh`
-
-    let pi_exec_path = tiles_lib_dir.join("pi/pi");
-
-    let pi_process = unsafe {
-        Command::new(pi_exec_path)
-            .arg("--mode")
-            .arg("rpc")
-            .arg("--append-system-prompt")
-            .arg(system_prompt)
-            .arg("--no-session")
-            .env("PI_CODING_AGENT_DIR", pi_agent_dir)
-            .env("PI_OFFLINE", "true")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .pre_exec(|| {
-                if let Err(err) = setsid() {
-                    Err(Into::into(err))
-                } else {
-                    Ok(())
-                }
-            })
-            .spawn()
-            .expect("failed to run Pi")
-    };
-    Ok(pi_process)
-}
-
-async fn send_to_pi(pi_child_stdin: &mut ChildStdin, payload_json: Value) -> Result<()> {
-    let payload_str = format!("{}\n", serde_json::to_string(&payload_json)?);
-    pi_child_stdin
-        .write_all(payload_str.as_bytes())
-        .await
-        .context("Failed to send to Pi's stdin")?;
-    pi_child_stdin
-        .flush()
-        .await
-        .context("Failed to flush Pi stdin")?;
-    Ok(())
-}
-
 async fn process_command(
     response_msg: PiResponseMessage,
     repl_session: &mut ReplSession,
-    pi_stdin: &mut ChildStdin,
-    pi_stdout: &mut ChildStdout,
+    agent_reader: &mut PiReader,
+    agent_writer: &mut PiWriter,
 ) -> Result<()> {
     match response_msg.command {
         CommandType::SetThinkingLevel => {
-            let state = get_pi_state(pi_stdin, pi_stdout).await?;
+            let state = agent_reader.get_pi_state(agent_writer).await?;
             match state.thinking_level.parse::<ReasoningEffort>() {
                 Ok(effort) => {
                     repl_session.reasoning = effort;
@@ -1231,97 +973,65 @@ fn build_status_lines(
         .collect()
 }
 
-fn handle_pi_message_update(msg_update: PiMessageUpdate) {
+fn handle_pi_message_update(msg_update: types::PiMessageUpdate) {
     match msg_update.assistant_message_event.r#type {
-        AsstMsgEventType::TextStart => {
+        types::AsstMsgEventType::TextStart => {
             println!();
             println!("{}\n", "**[Answer]**".bold());
             info!("msg text_start")
         }
-        AsstMsgEventType::TextDelta => {
+        types::AsstMsgEventType::TextDelta => {
             if let Some(delta) = msg_update.assistant_message_event.delta {
                 print!("{}", delta);
                 use std::io::Write;
                 std::io::stdout().flush().ok();
             }
         }
-        AsstMsgEventType::TextEnd => {
+        types::AsstMsgEventType::TextEnd => {
             info!("msg text_end")
         }
-        AsstMsgEventType::ThinkingStart => {
+        types::AsstMsgEventType::ThinkingStart => {
             println!();
             println!("{}\n", "**[Reasoning]**".dimmed());
         }
-        AsstMsgEventType::ThinkingDelta => {
+        types::AsstMsgEventType::ThinkingDelta => {
             if let Some(delta) = msg_update.assistant_message_event.delta {
                 print!("{}", delta.dimmed());
                 use std::io::Write;
                 std::io::stdout().flush().ok();
             }
         }
-        AsstMsgEventType::ThinkingEnd => {
+        types::AsstMsgEventType::ThinkingEnd => {
             println!();
         }
-        AsstMsgEventType::ToolcallStart => {
+        types::AsstMsgEventType::ToolcallStart => {
             info!("Selecting tool to execute");
             println!();
             let delta = "**[Tool Calling]**";
             println!("{}", delta.dimmed());
         }
-        AsstMsgEventType::ToolcallDelta => {
+        types::AsstMsgEventType::ToolcallDelta => {
             if let Some(delta) = msg_update.assistant_message_event.delta {
                 print!("{}", delta.dimmed());
                 use std::io::Write;
                 std::io::stdout().flush().ok();
             }
         }
-        AsstMsgEventType::ToolcallEnd => {
+        types::AsstMsgEventType::ToolcallEnd => {
             info!("Tool call selected");
         }
-        AsstMsgEventType::Done => {
+        types::AsstMsgEventType::Done => {
             info!("msg done event")
         }
-        AsstMsgEventType::Error => {
+        types::AsstMsgEventType::Error => {
             warn!("msg error event")
         }
         _ => (),
     }
 }
 
-async fn get_pi_state(
-    pi_stdin: &mut ChildStdin,
-    pi_stdout: &mut ChildStdout,
-) -> Result<GetStateData> {
-    let init_cmd_payload = json!({
-        "type": "get_state",
-    });
-    send_to_pi(pi_stdin, init_cmd_payload)
-        .await
-        .inspect_err(|_e| eprintln!("sending command to  pi failed"))?;
-
-    let reader = BufReader::new(pi_stdout);
-
-    if let Some(line) = reader.lines().next_line().await? {
-        let response: PiResponse = serde_json::from_str(&line)?;
-        if let PiResponse::Response(msg) = response {
-            let state: GetStateData =
-                serde_json::from_value(msg.data.expect("get state parsing failed"))?;
-            Ok(state)
-        } else {
-            Err(anyhow!("Failed to fetch initial state from Pi"))
-        }
-    } else {
-        Err(anyhow!("Failed to fetch session_id from Pi"))
-    }
-}
-
-async fn handle_repl_exit(pi_stdin: &mut ChildStdin) -> Result<()> {
-    let end_payload = json!({
-        "type": "abort",
-    });
-    let payload_str = format!("{}\n", serde_json::to_string(&end_payload)?);
-    pi_stdin.write_all(payload_str.as_bytes()).await?;
-    pi_stdin.flush().await?;
+async fn handle_repl_exit(agent_writer: &mut PiWriter) -> Result<()> {
+    pi::handle_graceful_exit(agent_writer).await?;
     println!("Exiting interactive mode");
     if !cfg!(debug_assertions) {
         match get_inference_config()? {
@@ -1338,7 +1048,7 @@ async fn handle_repl_exit(pi_stdin: &mut ChildStdin) -> Result<()> {
 }
 
 async fn handle_input_prompt(
-    pi_stdin: &mut ChildStdin,
+    agent_writer: &mut PiWriter,
     repl_session: &mut ReplSession,
     input: &str,
 ) -> Result<()> {
@@ -1357,14 +1067,15 @@ async fn handle_input_prompt(
         "type": "prompt",
         "message": final_input
     });
-    send_to_pi(pi_stdin, payload).await
+    agent_writer.send_to_pi(payload).await
 }
 
+//TODO: command type should be in repl.rs not in agent::types
 async fn handle_input_commands(
     cmd: String,
     repl_session: &mut ReplSession,
     db_conn: &Dbconn,
-    pi_stdin: &mut ChildStdin,
+    agent_writer: &mut PiWriter,
 ) -> Result<InputCommandResponse> {
     let args: Vec<&str> = cmd.split(" ").collect();
     let main_cmd = args.first().expect("Main command should be there");
@@ -1401,7 +1112,7 @@ async fn handle_input_commands(
             InputCommandResponse::ProcessNextInput
         }
         CommandType::Reasoning => {
-            if let Err(err) = set_reasoning_effort(pi_stdin, &args).await {
+            if let Err(err) = set_reasoning_effort(agent_writer, &args).await {
                 println!("Failed to set reasoning effort due to {}", err);
                 InputCommandResponse::ProcessNextInput
             } else {
@@ -1413,7 +1124,7 @@ async fn handle_input_commands(
                 "type": "get_commands",
             });
 
-            send_to_pi(pi_stdin, pi_cmd).await?;
+            agent_writer.send_to_pi(pi_cmd).await?;
             InputCommandResponse::WaitForNextLine
         }
         _ => InputCommandResponse::ProcessNextInput,
@@ -1424,7 +1135,7 @@ async fn handle_input_commands(
 async fn process_pi_agent_end_event(
     repl_session: &mut ReplSession,
     agent_end_event: PiAgentEndEvent,
-    pi_stdin: &mut ChildStdin,
+    agent: &mut PiWriter,
     db_conn: &Dbconn,
     current_user: &crate::core::account::local::User,
 ) -> Result<()> {
@@ -1438,7 +1149,7 @@ async fn process_pi_agent_end_event(
         let payload = json!({
             "type": "abort"
         });
-        send_to_pi(pi_stdin, payload).await?;
+        agent.send_to_pi(payload).await?;
         println!("An issue occurred, please try again!");
     }
 
@@ -1578,7 +1289,7 @@ fn format_assistant_content(msgs: Vec<PiMsgContent>) -> String {
     out
 }
 
-async fn set_reasoning_effort(pi_stdin: &mut ChildStdin, args: &[&str]) -> Result<()> {
+async fn set_reasoning_effort(agent_writer: &mut PiWriter, args: &[&str]) -> Result<()> {
     let args = if let Some((_main_command, sub_commands)) = args.split_first() {
         sub_commands
     } else {
@@ -1600,7 +1311,7 @@ async fn set_reasoning_effort(pi_stdin: &mut ChildStdin, args: &[&str]) -> Resul
         "level": &effort_str
     });
 
-    send_to_pi(pi_stdin, pi_cmd).await
+    agent_writer.send_to_pi(pi_cmd).await
 }
 
 /// Persist the reasoning level to Pi's settings.json so it survives restarts.
@@ -1631,6 +1342,9 @@ fn persist_default_thinking_level(level: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::agent::types::{
+        GetStateData, PiAgentEndEvent, PiModelInfo, PiMsgContent, PiMsgEvent,
+    };
     use crate::core::chats::create_session;
     use crate::core::chats::tests::create_user;
     use rusqlite::Connection;
@@ -1945,11 +1659,11 @@ mod tests {
         };
         let mut repl_session_b = ReplSession::new(&state);
 
-        let agent_end_event = PiAgentEndEvent {
+        let agent_end_event = PiAgentEndEvent{
             messages: vec![
-                PiMsgEvent {
+                PiMsgEvent{
                     role: Role::User,
-                    content: vec![PiMsgContent {
+                    content: vec![PiMsgContent{
                         r#type: String::from("text"),
                         text: Some("what is capital of India".to_string()),
                         thinking: None,

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -1,6 +1,6 @@
 use crate::core::account::atproto::{fetch_logged_in_data, login, share_session};
 use crate::core::account::local::get_current_user;
-use crate::core::agent::pi::{PiReader, PiWriter};
+use crate::core::agent::pi::{PiAgent, PiReader, PiWriter};
 use crate::core::agent::types::{
     CommandType, Commands, PiAgentEndEvent, PiMsgContent, PiResponse, PiResponseMessage,
     ReasoningEffort,
@@ -469,11 +469,9 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
         REMOTE_BOUND_PORT
     };
     // Setting up Pi rpc process handles
-    let pi_agent = pi::new(&modelname, &system_prompt, port)?;
+    let mut pi_agent = pi::new(&modelname, &system_prompt, port)?;
 
-    let (mut agent_reader, mut agent_writer) = pi_agent.split();
-
-    let pi_session_state = agent_reader.get_pi_state(&mut agent_writer).await?;
+    let pi_session_state = pi_agent.reader.get_pi_state(&mut pi_agent.writer).await?;
     let mut repl_session = ReplSession::new(&pi_session_state);
 
     // The great REPL loop
@@ -483,7 +481,7 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
         let input = match readline {
             Ok(line) => line.trim().to_string(),
             Err(_) => {
-                handle_repl_exit(&mut agent_writer).await?;
+                handle_repl_exit(&mut pi_agent.writer).await?;
                 break;
             }
         };
@@ -496,20 +494,21 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
         match handle_input(&input.to_lowercase()) {
             InputType::Skip => continue,
             InputType::Exit => {
-                handle_repl_exit(&mut agent_writer).await?;
+                handle_repl_exit(&mut pi_agent.writer).await?;
                 break;
             }
             InputType::Prompt => {
-                handle_input_prompt(&mut agent_writer, &mut repl_session, &input).await?;
+                handle_input_prompt(&mut pi_agent.writer, &mut repl_session, &input).await?;
             }
             InputType::Skill => {
                 let (_, skill_name) = input.split_at(1);
                 let skill_prompt = format!("/skill:{}", skill_name);
-                handle_input_prompt(&mut agent_writer, &mut repl_session, &skill_prompt).await?;
+                handle_input_prompt(&mut pi_agent.writer, &mut repl_session, &skill_prompt).await?;
             }
             InputType::Command(cmd) => {
-                let res = handle_input_commands(cmd, &mut repl_session, db_conn, &mut agent_writer)
-                    .await?;
+                let res =
+                    handle_input_commands(cmd, &mut repl_session, db_conn, &mut pi_agent.writer)
+                        .await?;
 
                 if let InputCommandResponse::ProcessNextInput = res {
                     continue;
@@ -526,13 +525,13 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
 
         // Reads the output from Pi and process and responds to the repl
 
-        while let Some(line) = agent_reader.next_line().await? {
+        while let Some(line) = pi_agent.reader.next_line().await? {
             if !running.load(std::sync::atomic::Ordering::SeqCst) {
                 info!("Ctrlc detected, aborting Pi ops");
                 let end_payload = json!({
                     "type": "abort",
                 });
-                agent_writer.send_to_pi(end_payload).await?;
+                pi_agent.writer.send_to_pi(end_payload).await?;
                 running.store(true, std::sync::atomic::Ordering::SeqCst);
                 continue;
             }
@@ -550,7 +549,7 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
                     process_pi_agent_end_event(
                         &mut repl_session,
                         agent_end_event,
-                        &mut agent_writer,
+                        &mut pi_agent.writer,
                         db_conn,
                         &current_user,
                     )
@@ -573,13 +572,8 @@ async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn)
                                 continue;
                             }
                             _ => {
-                                process_command(
-                                    response_msg,
-                                    &mut repl_session,
-                                    &mut agent_reader,
-                                    &mut agent_writer,
-                                )
-                                .await?;
+                                process_command(response_msg, &mut repl_session, &mut pi_agent)
+                                    .await?;
                                 break;
                             }
                         }
@@ -668,7 +662,8 @@ async fn wait_until_server_is_up() {
     }
 }
 
-fn get_default_modelfile(memory_mode: bool) -> Result<PathBuf> {
+//TODO: maybe move to config.rs, as it is used in daemon
+pub fn get_default_modelfile(memory_mode: bool) -> Result<PathBuf> {
     if memory_mode {
         let path = DefaultProvider.get_lib_dir()?.join("modelfiles/mem-agent");
         Ok(path)
@@ -724,12 +719,11 @@ async fn download_model(model_name: &str) -> Result<()> {
 async fn process_command(
     response_msg: PiResponseMessage,
     repl_session: &mut ReplSession,
-    agent_reader: &mut PiReader,
-    agent_writer: &mut PiWriter,
+    agent: &mut PiAgent,
 ) -> Result<()> {
     match response_msg.command {
         CommandType::SetThinkingLevel => {
-            let state = agent_reader.get_pi_state(agent_writer).await?;
+            let state = agent.reader.get_pi_state(&mut agent.writer).await?;
             match state.thinking_level.parse::<ReasoningEffort>() {
                 Ok(effort) => {
                     repl_session.reasoning = effort;

--- a/tiles/src/utils/config.rs
+++ b/tiles/src/utils/config.rs
@@ -24,7 +24,7 @@ use std::time::SystemTime;
 use std::{env, fs};
 use toml::Table;
 
-use crate::repl::{CompactionSettings, PiSettings};
+use crate::core::agent::types::{CompactionSettings, PiSettings};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ModelConfig {
@@ -115,6 +115,9 @@ const MODEL_SUB_PATH: &str = "models/huggingface/hub";
 pub const SYSTEM_BIN_DIR: &str = "/usr/local/bin";
 pub const SYSTEM_BIN_PATH: &str = "/usr/local/bin/tiles";
 pub const SYSTEM_LIB_DIR: &str = "/usr/local/share/tiles";
+pub const PY_PORT: u32 = 6969;
+// Used in remote inference, this is port where we open a TCP connection to proxy
+pub const REMOTE_BOUND_PORT: u32 = 9271;
 
 /// Bundled runtime directories under lib_dir removed on default uninstall.
 pub const LIB_RUNTIME_DIRS_TO_REMOVE: &[&str] = &["server", "modelfiles", "pi", "models"];
@@ -676,7 +679,7 @@ pub fn handle_pi_settings_config(settings_path: &PathBuf) -> Result<()> {
 #[cfg(test)]
 mod tests {
 
-    use crate::repl::ReasoningEffort;
+    use crate::core::agent::types::ReasoningEffort;
 
     use super::*;
     use serde_json::Value;

--- a/tiles/src/utils/lexicons.rs
+++ b/tiles/src/utils/lexicons.rs
@@ -3,7 +3,7 @@
 use atrium_api::types::string::Datetime;
 use serde::{Deserialize, Serialize};
 
-use crate::repl::PiMsgEvent;
+use crate::core::agent::types::PiMsgEvent;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SessionSnapshotRecord {

--- a/toolchain.toml
+++ b/toolchain.toml
@@ -3,7 +3,7 @@
 
 
 [embedded-tools]
-pi = "v0.67.68"
+pi = "v0.81.0"
 # fork of tiles-pi
 tiles-pi="v0.67.68"
 sqlcipher = "4.10.0"


### PR DESCRIPTION
- Now Pi agent is created in its own module, owned by a different struct. Such that a Pi agent instance can be controller by any caller be it daemon or repl.
- Also added few starter REST apis for communicating with Pi