### PR TITLE
Gemma 4 12b as default model along with auto enabling MTP if the model supports it

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,0 +1,76 @@
+name: Linux Release
+
+# Builds the Linux (x86_64) tarball whenever any tag is pushed
+# (stable, rc, nightly) and attaches it to the tag's GitHub Release.
+# install.sh resolves assets by pattern tiles-v*-{arch}-linux.tar.gz.
+
+on:
+  push:
+    tags: ["*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # No dtolnay/rust-toolchain here: its toolchain input is required and
+      # hardcoding it drifts from the repo pin. Runners ship rustup, which
+      # auto-installs the exact toolchain from rust-toolchain.toml on first use.
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install native dependencies and tools
+        run: |
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config jq
+          # venvstacks 0.8.0 final was never uploaded to PyPI; install from the git tag
+          pipx install "venvstacks @ git+https://github.com/lmstudio-ai/venvstacks.git@0.8.0"
+
+      - name: Install just
+        run: command -v just || cargo install just
+
+      - name: Fetch Pi linux tarball
+        run: |
+          VERSION=$(grep '^pi' toolchain.toml | head -1 | awk -F'"' '{print $2}')
+          echo "Using Pi ${VERSION} from toolchain.toml"
+          curl -fL -o pi-linux-x64.tar.gz \
+            "https://github.com/badlogic/pi-mono/releases/download/${VERSION}/pi-linux-x64.tar.gz"
+
+      - name: Fetch llama-server (latest ai-dock CUDA prebuilt)
+        run: ./scripts/fetch_llama_server.sh
+
+      - name: Build bundle
+        run: just bundle
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum tiles-v*-x86_64-linux.tar.gz > checksums.txt
+          cat checksums.txt
+
+      # Creates the release if missing, or uploads into the tag's existing
+      # release (same-named assets are overwritten on re-runs; existing
+      # release title/notes are preserved).
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            dist/tiles-v*-x86_64-linux.tar.gz
+            dist/checksums.txt
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -18,7 +18,12 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false — nothing here pushes git changes, so the
+      # write-capable token has no business sitting in .git/config for the
+      # rest of the job. The release upload uses the GITHUB_TOKEN env below.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # No dtolnay/rust-toolchain here: its toolchain input is required and
       # hardcoding it drifts from the repo pin. Runners ship rustup, which

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ tilekit/target
 tiles/target
 .DS_Store
 pkgroot/
+pkgroot_gguf/
+downloads/
 *.pkg
 models/
 pkgroot_models/

--- a/HACKING.md
+++ b/HACKING.md
@@ -68,7 +68,7 @@ This guide will help you set up a reproducible development environment for Tiles
    ./scripts/setup_dev_layout.sh
    ```
 
-   The default model (`unsloth/gpt-oss-20b-GGUF`) is downloaded automatically on the first `cargo run`.
+   The default model (`unsloth/gemma-4-12b-it-GGUF`, Q4_K_M) is downloaded automatically on the first `cargo run`. A different quantization can be selected in the modelfile with `FROM unsloth/gemma-4-12b-it-GGUF:Q8_0` (ollama-style tag). MTP speculative decoding auto-enables when the model ships an MTP head (`mtp-*.gguf` next to the main model); disable with `[llama] mtp = false` in config.toml.
 
 ### Embedding Pi
 

--- a/modelfiles/gemma-4-12b-gguf
+++ b/modelfiles/gemma-4-12b-gguf
@@ -1,4 +1,4 @@
-FROM unsloth/gemma-4-12b-it-GGUF
+FROM unsloth/gemma-4-12b-it-GGUF:Q4_K_M
 SYSTEM """
 You are Tiles, a local-first private AI assistant.
 

--- a/modelfiles/gpt-oss-gguf
+++ b/modelfiles/gpt-oss-gguf
@@ -1,4 +1,4 @@
-FROM unsloth/gpt-oss-20b-GGUF
+FROM unsloth/gpt-oss-20b-GGUF:Q4_K_M
 SYSTEM """
 You are Tiles, a local-first private AI assistant.
 

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -64,6 +64,17 @@ codesign --force \
   --strict \
   "${PKG_LIBS_PATH}/pi/pi"
 
+echo "Signing Pi native modules..."
+
+find "${PKG_LIBS_PATH}/pi" -name '*.node' -type f | while read -r node_bin; do
+  codesign --force \
+    --sign "$DEVELOPER_ID_APPLICATION" \
+    --options runtime \
+    --timestamp \
+    --strict \
+    "$node_bin"
+done
+
   
 # Build venvstack and move to /usr/local/share/tiles
 # 

--- a/pkg/build_model.sh
+++ b/pkg/build_model.sh
@@ -32,7 +32,11 @@ download() {
         echo "${file} already downloaded, skipping"
     else
         echo "Downloading ${url}"
-        curl -fL --retry 3 -C - -o "downloads/${file}" "${url}"
+        # Download to a .part temp and rename only on success, so an
+        # interrupted download can never satisfy the cached-file check.
+        # The .part file persists for -C - to resume on the next run.
+        curl -fL --retry 3 -C - -o "downloads/${file}.part" "${url}"
+        mv "downloads/${file}.part" "downloads/${file}"
     fi
 }
 

--- a/pkg/build_model.sh
+++ b/pkg/build_model.sh
@@ -1,16 +1,62 @@
-# model pkg command, run when model changes, or need a local copy for final pkg
-MODELS_VERSION=1.0
+#!/usr/bin/env bash
+# Builds the offline-model pkg: bundles the default gemma 4 12b GGUF (Q4_K_M)
+# + MTP head so Tiles works without any network access.
+#
+# Since pkgbuild can't package very large files, the model dir is tarballed
+# and split into 2 GB parts; pkg/scripts/gguf/postinstall rejoins + extracts
+# them into /usr/local/share/tiles/models/huggingface/hub on install.
+#
+# Run when the bundled model changes, or a local copy is needed for the
+# full/offline installer (`just bundle_pkg_full`).
+set -euo pipefail
 
-# pkgbuild --root pkgroot_gptoss_gguf --identifier com.tilesprivacy.tiles_models_gguf --version "$MODELS_VERSION" pkg/tiles-model_gguf.pkg
+MODELS_VERSION=2.0
 
-# Since pkg installer can't build with large files (here 11gb model) we
-# first make a tar of it using `tar --zstd -cf gpt-oss-20b-GGUF.tar.zst huggingface/hub/models--`
-# (huggingface is dir from which HF stuff starts with)
+REPO="unsloth/gemma-4-12b-it-GGUF"
+GGUF_FILE="${TILES_GEMMA_QUANT:-gemma-4-12b-it-Q4_K_M.gguf}"
+MTP_FILE="${TILES_GEMMA_MTP:-mtp-gemma-4-12b-it.gguf}"
 
-# split into multiple 2gb files using `split -b 2048m gpt-oss-20b-GGUF.tar.zst gpt-oss-20b-GGUF.tar.zst.part.`.
+TARBALL="gemma-4-12b-it-GGUF.tar.gz"
 
-# and then during installation, joins each and extract it to the directory
+STAGING="pkg/staging_gguf"
+PKGROOT="pkgroot_gguf"
+MODELS_HUB_DIR="${PKGROOT}/usr/local/share/tiles/models/huggingface/hub"
+# HF hub cache dir name: org/repo -> models--org--repo
+MODEL_DIR_NAME="models--$(echo "${REPO}" | tr '/' '-')"
+STAGING_MODEL_DIR="${STAGING}/${MODEL_DIR_NAME}"
 
-# 
+download() {
+    local file="$1"
+    local url="https://huggingface.co/${REPO}/resolve/main/${file}"
+    if [[ -f "downloads/${file}" ]]; then
+        echo "${file} already downloaded, skipping"
+    else
+        echo "Downloading ${url}"
+        curl -fL --retry 3 -C - -o "downloads/${file}" "${url}"
+    fi
+}
 
-pkgbuild --root pkgroot_gptoss_gguf --scripts pkg/scripts/gguf  --identifier com.tilesprivacy.tiles_models_gguf --version "$MODELS_VERSION" pkg/tiles-model_gguf.pkg
+mkdir -p downloads "${STAGING_MODEL_DIR}" "${MODELS_HUB_DIR}"
+
+download "${GGUF_FILE}"
+download "${MTP_FILE}"
+
+cp "downloads/${GGUF_FILE}" "downloads/${MTP_FILE}" "${STAGING_MODEL_DIR}/"
+
+echo "Creating ${TARBALL}..."
+tar -czf "${STAGING}/${TARBALL}" -C "${STAGING}" "${MODEL_DIR_NAME}"
+
+echo "Splitting into 2 GB parts..."
+rm -f "${MODELS_HUB_DIR}/${TARBALL}.part."*
+split -b 2048m "${STAGING}/${TARBALL}" "${MODELS_HUB_DIR}/${TARBALL}.part."
+
+rm -rf "${STAGING}"
+
+pkgbuild \
+    --root "${PKGROOT}" \
+    --scripts pkg/scripts/gguf \
+    --identifier com.tilesprivacy.tiles_models_gguf \
+    --version "${MODELS_VERSION}" \
+    pkg/tiles-model_gguf.pkg
+
+rm -rf "${PKGROOT}"

--- a/pkg/scripts/gguf/postinstall
+++ b/pkg/scripts/gguf/postinstall
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-set -e 
-# Since pkg installer can't build with large files (here 11gb model) we
-# split into multiple 2gb files while building the installer
-# and then during installation, joins each and extract it to the directory
+set -e
+# Since pkg installer can't build with large files (the default model is
+# several GB), the model dir is split into multiple 2gb files while building
+# the installer; this script joins them back and extracts them in place.
 
 MODELS_DIR="/usr/local/share/tiles/models/huggingface/hub"
 
 cd "${MODELS_DIR}"
 
-cat gpt-oss-20b-GGUF.tar.gz.part.* > gpt-oss-20b-GGUF.tar.gz
+cat gemma-4-12b-it-GGUF.tar.gz.part.* > gemma-4-12b-it-GGUF.tar.gz
 
-tar -xzf gpt-oss-20b-GGUF.tar.gz -C .
+tar -xzf gemma-4-12b-it-GGUF.tar.gz -C .
 
-rm gpt-oss-20b-GGUF.tar.gz.part.*
+rm -f gemma-4-12b-it-GGUF.tar.gz.part.*
 
-rm gpt-oss-20b-GGUF.tar.gz
+rm -f gemma-4-12b-it-GGUF.tar.gz

--- a/scripts/build_with_pi_dev.sh
+++ b/scripts/build_with_pi_dev.sh
@@ -26,8 +26,6 @@ TARBALL="pi-${PLATFORM}.tar.gz"
 
 TAR_URL="https://github.com/badlogic/pi-mono/releases/download/${VERSION}/${TARBALL}"
 
-# TAR_URL="https://github.com/tilesprivacy/tiles-pi/releases/download/${VERSION}/${TARBALL}"
-
 echo "Downloading Pi ${VERSION} for ${PLATFORM}..."
 curl -fL -o "$TARBALL" "$TAR_URL"
 

--- a/server/backend/llama_server/process.py
+++ b/server/backend/llama_server/process.py
@@ -109,24 +109,29 @@ def build_llama_server_command(gguf_path: Path, llama_config: dict[str, Any]) ->
     if no_mmap is True:
         cmd.append("--no-mmap")
 
-    if llama_config.get("mtp") is True:
-        mtp_path = find_mtp_gguf_file(gguf_path)
-        if mtp_path is None:
-            logger.warning(
-                "MTP enabled but no MTP GGUF found next to %s. "
-                "Re-run model download or set mtp = false in config.",
-                gguf_path,
-            )
-        else:
-            cmd.extend(
-                [
-                    "--spec-type",
-                    "draft-mtp",
-                    "--spec-draft-model",
-                    str(mtp_path),
-                ]
-            )
-            logger.info("MTP speculative decoding enabled with %s", mtp_path)
+    # MTP speculative decoding: auto-enabled when the model ships an MTP
+    # head, unless explicitly disabled. An explicit `mtp = true` with no
+    # file on disk warns and runs without it.
+    mtp_config = llama_config.get("mtp")
+    mtp_path = find_mtp_gguf_file(gguf_path)
+    if mtp_config is False:
+        pass
+    elif mtp_path is not None:
+        cmd.extend(
+            [
+                "--spec-type",
+                "draft-mtp",
+                "--spec-draft-model",
+                str(mtp_path),
+            ]
+        )
+        logger.info("MTP speculative decoding enabled with %s", mtp_path)
+    elif mtp_config is True:
+        logger.warning(
+            "MTP enabled but no MTP GGUF found next to %s. "
+            "Re-run model download or set mtp = false in config.",
+            gguf_path,
+        )
 
     return cmd
 

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -182,7 +182,7 @@ class CFunctionCallOutputItemParam(BaseModel):
 
 
 class ResponsesRequest(BaseModel):
-    model: str = "mlx-community/gpt-oss-20b-MXFP4-Q4"
+    model: str = "unsloth/gemma-4-12b-it-GGUF"
     input: (
         str
         | list[

--- a/server/stack/macos/requirements/cpython3.13/pylock.cpython3_13.toml
+++ b/server/stack/macos/requirements/cpython3.13/pylock.cpython3_13.toml
@@ -4,3 +4,4 @@
 lock-version = "1.0"
 created-by = "uv"
 requires-python = "==3.13.*"
+packages = []

--- a/server/tests/test_llama_server_process.py
+++ b/server/tests/test_llama_server_process.py
@@ -28,8 +28,9 @@ def test_is_server_ready_requires_health_ok():
         assert is_server_ready() is True
 
 
-def test_build_llama_server_command_omits_unset_flags():
-    gguf = Path("/tmp/model.gguf")
+def test_build_llama_server_command_omits_unset_flags(tmp_path: Path):
+    gguf = tmp_path / "model.gguf"
+    gguf.write_bytes(b"x")
 
     with patch(
         "server.backend.llama_server.process.resolve_llama_server_binary",
@@ -49,8 +50,9 @@ def test_build_llama_server_command_omits_unset_flags():
     ]
 
 
-def test_build_llama_server_command_includes_optional_flags():
-    gguf = Path("/tmp/model.gguf")
+def test_build_llama_server_command_includes_optional_flags(tmp_path: Path):
+    gguf = tmp_path / "model.gguf"
+    gguf.write_bytes(b"x")
     config = {
         "context_length": 32768,
         "gpu_layers": 12,
@@ -77,6 +79,69 @@ def test_build_llama_server_command_includes_optional_flags():
     assert "--flash-attn" in cmd and "on" in cmd
     assert "--no-mmap" in cmd
     assert "--jinja" in cmd
+    assert "--spec-type" not in cmd
+
+
+def test_mtp_auto_enables_when_head_present(tmp_path: Path):
+    gguf = tmp_path / "model.gguf"
+    gguf.write_bytes(b"x")
+    (tmp_path / "mtp-gemma-4-12b-it.gguf").write_bytes(b"x")
+
+    with patch(
+        "server.backend.llama_server.process.resolve_llama_server_binary",
+        return_value="/usr/bin/llama-server",
+    ):
+        cmd = build_llama_server_command(gguf, {})
+
+    assert "--spec-type" in cmd and "draft-mtp" in cmd
+    draft_idx = cmd.index("--spec-draft-model")
+    assert cmd[draft_idx + 1] == str(tmp_path / "mtp-gemma-4-12b-it.gguf")
+
+
+def test_mtp_stays_off_without_head(tmp_path: Path):
+    gguf = tmp_path / "model.gguf"
+    gguf.write_bytes(b"x")
+
+    with patch(
+        "server.backend.llama_server.process.resolve_llama_server_binary",
+        return_value="/usr/bin/llama-server",
+    ):
+        cmd = build_llama_server_command(gguf, {})
+
+    assert "--spec-type" not in cmd
+    assert "--spec-draft-model" not in cmd
+
+
+def test_mtp_explicit_true_without_head_warns(tmp_path: Path):
+    gguf = tmp_path / "model.gguf"
+    gguf.write_bytes(b"x")
+
+    with (
+        patch(
+            "server.backend.llama_server.process.resolve_llama_server_binary",
+            return_value="/usr/bin/llama-server",
+        ),
+        patch("server.backend.llama_server.process.logger") as logger,
+    ):
+        cmd = build_llama_server_command(gguf, {"mtp": True})
+
+    assert "--spec-type" not in cmd
+    assert logger.warning.called
+
+
+def test_mtp_explicit_false_overrides_head(tmp_path: Path):
+    gguf = tmp_path / "model.gguf"
+    gguf.write_bytes(b"x")
+    (tmp_path / "mtp-gemma-4-12b-it.gguf").write_bytes(b"x")
+
+    with patch(
+        "server.backend.llama_server.process.resolve_llama_server_binary",
+        return_value="/usr/bin/llama-server",
+    ):
+        cmd = build_llama_server_command(gguf, {"mtp": False})
+
+    assert "--spec-type" not in cmd
+    assert "--spec-draft-model" not in cmd
 
 
 def test_ensure_running_reuses_running_server(tmp_path: Path):

--- a/tilekit/src/modelfile.rs
+++ b/tilekit/src/modelfile.rs
@@ -127,6 +127,8 @@ impl Parameter {
 #[derive(Debug, Clone)]
 pub struct Modelfile {
     pub from: Option<String>,
+    /// Quantization tag from `FROM repo:QUANT` (e.g. Q8_0), if any
+    pub quant: Option<String>,
     pub parameters: Vec<Parameter>,
     pub template: Option<String>,
     pub adapter: Option<String>,
@@ -137,10 +139,22 @@ pub struct Modelfile {
     pub errors: Vec<String>,
 }
 
+/// Split a `FROM` value into (repo, quant).
+/// `unsloth/gemma-4-12b-it-GGUF:Q8_0` -> ("unsloth/gemma-4-12b-it-GGUF", Some("Q8_0"))
+/// `unsloth/gemma-4-12b-it-GGUF` -> ("unsloth/gemma-4-12b-it-GGUF", None)
+/// HF repo names cannot contain ':', so the last ':' is always the tag separator.
+pub fn split_model_spec(spec: &str) -> (&str, Option<&str>) {
+    match spec.rsplit_once(':') {
+        Some((repo, quant)) if !repo.is_empty() && !quant.is_empty() => (repo, Some(quant)),
+        _ => (spec, None),
+    }
+}
+
 impl Modelfile {
     pub fn new() -> Self {
         Self {
             from: None,
+            quant: None,
             data: vec![],
             parameters: vec![],
             template: None,
@@ -158,7 +172,9 @@ impl Modelfile {
             self.errors.push(error.clone());
             Err(error)
         } else {
-            self.from = Some(value.to_owned());
+            let (repo, quant) = split_model_spec(value.trim());
+            self.from = Some(repo.to_owned());
+            self.quant = quant.map(|q| q.to_owned());
             self.data.push(format!("FROM {}", value));
             Ok(())
         }
@@ -555,7 +571,8 @@ mod tests {
     #[test]
     fn test_parse_modelfile_from_file() {
         let modelfile = parse_from_file("fixtures/a.modelfile").unwrap();
-        assert_eq!(modelfile.from, Some("llama3.2:latest".to_owned()))
+        assert_eq!(modelfile.from, Some("llama3.2".to_owned()));
+        assert_eq!(modelfile.quant, Some("latest".to_owned()));
     }
 
     #[test]
@@ -594,6 +611,64 @@ mod tests {
         ";
         let modelfile = parse(modelfile_content)?;
         assert_eq!(modelfile.from.unwrap(), String::from("llama3.2"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_with_quant_tag() {
+        let modelfile = parse("FROM unsloth/gemma-4-12b-it-GGUF:Q8_0").unwrap();
+        assert_eq!(
+            modelfile.from.unwrap(),
+            "unsloth/gemma-4-12b-it-GGUF".to_owned()
+        );
+        assert_eq!(modelfile.quant.unwrap(), "Q8_0".to_owned());
+    }
+
+    #[test]
+    fn test_from_without_quant_tag() {
+        let modelfile = parse("FROM unsloth/gemma-4-12b-it-GGUF").unwrap();
+        assert_eq!(
+            modelfile.from.unwrap(),
+            "unsloth/gemma-4-12b-it-GGUF".to_owned()
+        );
+        assert_eq!(modelfile.quant, None);
+    }
+
+    #[test]
+    fn test_from_with_empty_quant_tag() {
+        // trailing ':' is not treated as a quant tag
+        let modelfile = parse("FROM unsloth/gemma-4-12b-it-GGUF:").unwrap();
+        assert_eq!(
+            modelfile.from.unwrap(),
+            "unsloth/gemma-4-12b-it-GGUF:".to_owned()
+        );
+        assert_eq!(modelfile.quant, None);
+    }
+
+    #[test]
+    fn test_split_model_spec() {
+        assert_eq!(
+            split_model_spec("unsloth/gemma-4-12b-it-GGUF:Q8_0"),
+            ("unsloth/gemma-4-12b-it-GGUF", Some("Q8_0"))
+        );
+        assert_eq!(
+            split_model_spec("unsloth/gemma-4-12b-it-GGUF"),
+            ("unsloth/gemma-4-12b-it-GGUF", None)
+        );
+        assert_eq!(split_model_spec(":Q8_0"), (":Q8_0", None));
+        assert_eq!(split_model_spec("repo:"), ("repo:", None));
+    }
+
+    #[test]
+    fn test_modelfile_builder_with_quant() -> Result<(), Box<dyn Error>> {
+        let mut modelfile = Modelfile::new();
+        modelfile.add_from("unsloth/gemma-4-12b-it-GGUF:Q8_0")?;
+        assert!(modelfile.build().is_ok());
+        assert_eq!(
+            modelfile.from.as_deref(),
+            Some("unsloth/gemma-4-12b-it-GGUF")
+        );
+        assert_eq!(modelfile.quant.as_deref(), Some("Q8_0"));
         Ok(())
     }
 }

--- a/tiles/src/daemon/agent.rs
+++ b/tiles/src/daemon/agent.rs
@@ -26,7 +26,8 @@ async fn start_agent(State(state): State<Arc<AppState>>) -> Result<impl IntoResp
     let default_modelfile = tilekit::modelfile::parse_from_file(&modelfile_path.to_string_lossy())
         .map_err(|e| AppError::InternalServerError(e.to_string()))?;
 
-    let modelname = model_spec(&default_modelfile);
+    let modelname =
+        model_spec(&default_modelfile).map_err(|e| AppError::InternalServerError(e.to_string()))?;
 
     let system_prompt = default_modelfile.system.clone().unwrap_or("".to_owned());
 

--- a/tiles/src/daemon/agent.rs
+++ b/tiles/src/daemon/agent.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use crate::{
     core::agent::pi::{self},
     daemon::{ApiResponse, AppError, AppState},
-    repl::get_default_modelfile,
+    repl::{get_default_modelfile, model_spec},
     utils::config::PY_PORT,
 };
 
@@ -22,14 +22,11 @@ pub fn agent_router() -> Router<Arc<AppState>> {
 
 async fn start_agent(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
     let modelfile_path =
-        get_default_modelfile(false).map_err(|e| AppError::ModelFileNotFound(e.to_string()))?;
+        get_default_modelfile().map_err(|e| AppError::ModelFileNotFound(e.to_string()))?;
     let default_modelfile = tilekit::modelfile::parse_from_file(&modelfile_path.to_string_lossy())
         .map_err(|e| AppError::InternalServerError(e.to_string()))?;
 
-    let modelname = default_modelfile
-        .from
-        .clone()
-        .expect("failed to take modelfile from Option");
+    let modelname = model_spec(&default_modelfile);
 
     let system_prompt = default_modelfile.system.clone().unwrap_or("".to_owned());
 

--- a/tiles/src/main.rs
+++ b/tiles/src/main.rs
@@ -200,9 +200,6 @@ struct RunFlags {
     #[arg(short = 'r', long, default_value_t = 10, hide = true)]
     relay_count: u32,
 
-    /// Switches the mode to memory, used for interacting with memory models.
-    #[arg(short = 'm', long, hide = true)]
-    memory: bool,
     // Future flags go here:
     // #[arg(long, default_value_t = 6969)]
     // port: u16,
@@ -432,7 +429,6 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             let run_args = RunArgs {
                 modelfile_path: None,
                 relay_count: cli.flags.relay_count,
-                memory: cli.flags.memory,
                 llama_config: llama_config_from_flags(&cli.flags),
                 remote: cli.flags.remote,
             };
@@ -464,7 +460,6 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             let run_args = RunArgs {
                 modelfile_path,
                 relay_count: flags.relay_count,
-                memory: flags.memory,
                 llama_config: llama_config_from_flags(&flags),
                 remote: flags.remote,
             };

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -71,7 +71,6 @@ impl BenchmarkMetrics {
 pub struct RunArgs {
     pub modelfile_path: Option<String>,
     pub relay_count: u32,
-    pub memory: bool,
     pub llama_config: Option<LlamaConfig>,
     pub remote: Option<String>,
 }
@@ -121,13 +120,13 @@ pub async fn run(run_args: RunArgs, db_conn: &Dbconn) -> Result<()> {
                 return Ok(());
             }
         };
-        let default_modelfile = get_default_modelfile(run_args.memory)
+        let default_modelfile = get_default_modelfile()
             .ok()
             .and_then(|path| tilekit::modelfile::parse_from_file(path.to_str()?).ok())
             .unwrap_or_else(|| modelfile.clone());
         (modelfile, default_modelfile)
     } else {
-        let default_modelfile_path = get_default_modelfile(run_args.memory)?;
+        let default_modelfile_path = get_default_modelfile()?;
         let default_modelfile = match tilekit::modelfile::parse_from_file(
             default_modelfile_path
                 .to_str()
@@ -440,10 +439,7 @@ async fn run_model_with_server(
 
 #[allow(unused_assignments)]
 async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn) -> Result<()> {
-    let modelname = modelfile
-        .from
-        .clone()
-        .ok_or_else(|| anyhow!("Error getting FROM from modelfile due to"))?;
+    let modelname = model_spec(modelfile);
 
     update_current_model(&modelname).context("Failed to update current model in config.toml")?;
     let system_prompt = modelfile.system.clone().unwrap_or("".to_owned());
@@ -603,6 +599,47 @@ pub async fn ping() -> Result<()> {
     }
 }
 
+/// Full `repo:quant` spec used as the model identity across config, Pi and the py server
+pub fn model_spec(modelfile: &Modelfile) -> String {
+    match &modelfile.quant {
+        Some(quant) => format!("{}:{}", modelfile.from.clone().expect("no FROM"), quant),
+        None => modelfile.from.clone().expect("no FROM"),
+    }
+}
+
+fn resolve_gguf_path(model_cache_path: &PathBuf, quant: Option<&str>) -> Result<PathBuf> {
+    let Some(quant) = quant else {
+        return Ok(model_cache_path.clone());
+    };
+    let suffix = format!("{}.gguf", quant.to_lowercase());
+    let matches: Vec<PathBuf> = fs::read_dir(model_cache_path)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.extension().is_some_and(|ext| ext == "gguf")
+                && p.file_name().is_some_and(|n| {
+                    let name = n.to_string_lossy().to_lowercase();
+                    name.ends_with(&suffix) && !name.contains("mmproj") && !name.contains("mtp")
+                })
+        })
+        .collect();
+    match matches.len() {
+        0 => Err(anyhow!(
+            "No gguf matching quant '{}' found in {}",
+            quant,
+            model_cache_path.display()
+        )),
+        1 => Ok(matches[0].clone()),
+        _ => Err(anyhow!(
+            "Multiple gguf files matching quant '{}' in {}: {:?}",
+            quant,
+            model_cache_path.display(),
+            matches
+        )),
+    }
+}
+
 async fn load_model(
     modelfile: &Modelfile,
     default_modelfile: &Modelfile,
@@ -616,26 +653,24 @@ async fn load_model(
         ));
     }
     let model_name = modelfile.from.clone().unwrap();
+    let quant = modelfile.quant.as_deref();
     let model_cache_res = get_model_cache(&model_name);
 
     if model_cache_res.is_err() {
-        download_model(&model_name).await?;
+        download_model(&model_name, quant).await?;
         return Box::pin(load_model(modelfile, default_modelfile, memory_path, 0)).await;
     }
 
     // If loading fails it most probably a partial downloaded
     // model present, so we try to resume the download
-    if load_model_in_py(
-        modelfile,
-        default_modelfile,
-        memory_path,
-        &model_cache_res.unwrap(),
-    )
-    .await
-    .is_err()
+    let model_cache_path = model_cache_res.unwrap();
+    let gguf_path = resolve_gguf_path(&model_cache_path, quant)?;
+    if load_model_in_py(modelfile, default_modelfile, memory_path, &gguf_path)
+        .await
+        .is_err()
     {
         log::warn!("Load model failed, resuming the partial download");
-        download_model(&model_name).await?;
+        download_model(&model_name, quant).await?;
         Box::pin(load_model(
             modelfile,
             default_modelfile,
@@ -662,17 +697,11 @@ async fn wait_until_server_is_up() {
     }
 }
 
-//TODO: maybe move to config.rs, as it is used in daemon
-pub fn get_default_modelfile(memory_mode: bool) -> Result<PathBuf> {
-    if memory_mode {
-        let path = DefaultProvider.get_lib_dir()?.join("modelfiles/mem-agent");
-        Ok(path)
-    } else {
-        let path = DefaultProvider
-            .get_lib_dir()?
-            .join("modelfiles/gpt-oss-gguf");
-        Ok(path)
-    }
+pub fn get_default_modelfile() -> Result<PathBuf> {
+    let path = DefaultProvider
+        .get_lib_dir()?
+        .join("modelfiles/gemma-4-12b-gguf");
+    Ok(path)
 }
 
 async fn load_model_in_py(
@@ -682,10 +711,7 @@ async fn load_model_in_py(
     model_cache_path: &PathBuf,
 ) -> Result<()> {
     let client = Client::new();
-    let model_name = modelfile
-        .from
-        .clone()
-        .expect("Failed to get `FROM` of modelfile");
+    let model_name = model_spec(modelfile);
     let body = json!({
         "model": model_name,
         "memory_path": memory_path,
@@ -706,8 +732,8 @@ async fn load_model_in_py(
     }
 }
 
-async fn download_model(model_name: &str) -> Result<()> {
-    match pull_model(model_name).await {
+async fn download_model(model_name: &str, quant: Option<&str>) -> Result<()> {
+    match pull_model(model_name, quant).await {
         Ok(_) => {
             println!("\nDownloading completed \n");
             Ok(())
@@ -1345,8 +1371,8 @@ mod tests {
 
     #[test]
     fn default_modelfile_uses_platform_default() {
-        let path = get_default_modelfile(false).expect("default modelfile should resolve");
-        assert!(path.ends_with("modelfiles/gpt-oss-gguf"));
+        let path = get_default_modelfile().expect("default modelfile should resolve");
+        assert!(path.ends_with("modelfiles/gemma-4-12b-gguf"));
     }
 
     #[test]

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -439,7 +439,7 @@ async fn run_model_with_server(
 
 #[allow(unused_assignments)]
 async fn start_repl(modelfile: &Modelfile, run_args: &RunArgs, db_conn: &Dbconn) -> Result<()> {
-    let modelname = model_spec(modelfile);
+    let modelname = model_spec(modelfile)?;
 
     update_current_model(&modelname).context("Failed to update current model in config.toml")?;
     let system_prompt = modelfile.system.clone().unwrap_or("".to_owned());
@@ -600,11 +600,15 @@ pub async fn ping() -> Result<()> {
 }
 
 /// Full `repo:quant` spec used as the model identity across config, Pi and the py server
-pub fn model_spec(modelfile: &Modelfile) -> String {
-    match &modelfile.quant {
-        Some(quant) => format!("{}:{}", modelfile.from.clone().expect("no FROM"), quant),
-        None => modelfile.from.clone().expect("no FROM"),
-    }
+pub fn model_spec(modelfile: &Modelfile) -> Result<String> {
+    let from = modelfile
+        .from
+        .clone()
+        .ok_or_else(|| anyhow!("Modelfile missing FROM instruction"))?;
+    Ok(match &modelfile.quant {
+        Some(quant) => format!("{}:{}", from, quant),
+        None => from,
+    })
 }
 
 fn resolve_gguf_path(model_cache_path: &PathBuf, quant: Option<&str>) -> Result<PathBuf> {
@@ -664,11 +668,16 @@ async fn load_model(
     // If loading fails it most probably a partial downloaded
     // model present, so we try to resume the download
     let model_cache_path = model_cache_res.unwrap();
-    let gguf_path = resolve_gguf_path(&model_cache_path, quant)?;
-    if load_model_in_py(modelfile, default_modelfile, memory_path, &gguf_path)
-        .await
-        .is_err()
-    {
+    let load_res = match resolve_gguf_path(&model_cache_path, quant) {
+        Ok(gguf_path) => {
+            load_model_in_py(modelfile, default_modelfile, memory_path, &gguf_path).await
+        }
+        Err(err) => {
+            log::warn!("Failed to resolve GGUF for the model: {}", err);
+            Err(anyhow!(err))
+        }
+    };
+    if load_res.is_err() {
         log::warn!("Load model failed, resuming the partial download");
         download_model(&model_name, quant).await?;
         Box::pin(load_model(
@@ -711,7 +720,7 @@ async fn load_model_in_py(
     model_cache_path: &PathBuf,
 ) -> Result<()> {
     let client = Client::new();
-    let model_name = model_spec(modelfile);
+    let model_name = model_spec(modelfile)?;
     let body = json!({
         "model": model_name,
         "memory_path": memory_path,

--- a/tiles/src/utils/config.rs
+++ b/tiles/src/utils/config.rs
@@ -418,10 +418,13 @@ fn save_root_config(config: &RootConfig) -> Result<()> {
     fs::remove_file(tmp_path)?;
     Ok(())
 }
-/// Get the apt path where the model in the system
+/// Get the apt path where the model in the system.
+/// `model_name` may carry a `:quant` tag (e.g. `unsloth/gemma-4-12b-it-GGUF:Q8_0`),
+/// which is stripped before resolving the HF cache dir.
 pub fn get_model_cache(model_name: &str) -> Result<PathBuf> {
-    let hf_model_dir = if model_name.contains("/") {
-        let model_spec_parts = model_name.split("/").collect::<Vec<&str>>();
+    let (repo, _quant) = tilekit::modelfile::split_model_spec(model_name);
+    let hf_model_dir = if repo.contains("/") {
+        let model_spec_parts = repo.split("/").collect::<Vec<&str>>();
         format!("models--{}--{}", model_spec_parts[0], model_spec_parts[1])
     } else {
         return Err(anyhow!("Modelfile not found"));

--- a/tiles/src/utils/hf_model_downloader.rs
+++ b/tiles/src/utils/hf_model_downloader.rs
@@ -7,23 +7,35 @@ use hf_hub::api::{
 
 use crate::utils::config::get_or_create_model_download_path;
 
-/// Download the entire model (including snapshot) for the given model name
-pub async fn pull_model(model_name: &str) -> Result<()> {
-    snapshot_download(model_name).await
+/// Default quantization pulled when a modelfile doesn't specify one
+pub const DEFAULT_QUANT: &str = "Q4_K_M";
+
+/// Download the model snapshot for the given model name and quantization.
+/// `quant` selects the gguf variant (e.g. `Q8_0`); falls back to `Q4_K_M`.
+pub async fn pull_model(model_name: &str, quant: Option<&str>) -> Result<()> {
+    snapshot_download(model_name, quant).await
 }
 
-pub async fn snapshot_download(modelname: &str) -> Result<()> {
-    let allow_patterns = [
+pub async fn snapshot_download(modelname: &str, quant: Option<&str>) -> Result<()> {
+    let quant = quant.unwrap_or(DEFAULT_QUANT);
+    let metadata_patterns = [
         ".json",
         ".txt",
         ".safetensors",
         ".md",
         ".gitattributes",
         "LICENSE",
-        "Q4_K_M.gguf",
-        "q4_k_m.gguf",
-        "mtp-gemma-4-12b-it.gguf",
     ];
+    let quant_gguf = format!("{}.gguf", quant.to_lowercase());
+    let allow_patterns: Vec<String> = metadata_patterns
+        .iter()
+        .map(|p| (*p).to_owned())
+        .chain([
+            quant_gguf.clone(),
+            // MTP head for speculative decoding, quant-independent
+            "mtp-gemma-4-12b-it.gguf".to_owned(),
+        ])
+        .collect();
     let api_build_result = ApiBuilder::new()
         .with_progress(true)
         .with_cache_dir(get_or_create_model_download_path()?)
@@ -38,11 +50,41 @@ pub async fn snapshot_download(modelname: &str) -> Result<()> {
                         .siblings
                         .iter()
                         .filter(|sibling| {
-                            allow_patterns
-                                .iter()
-                                .any(|pat| sibling.rfilename.ends_with(pat))
+                            allow_patterns.iter().any(|pat| {
+                                sibling.rfilename.ends_with(pat.as_str())
+                                    || sibling.rfilename.to_lowercase().ends_with(&quant_gguf)
+                            })
                         })
                         .collect::<Vec<&Siblings>>();
+
+                    // failfast when the requested quant doesn't exist in the
+                    // repo, instead of downloading metadata.
+                    if !filtered_siblings
+                        .iter()
+                        .any(|sibling| is_main_gguf(&sibling.rfilename))
+                    {
+                        let available: Vec<&str> = repo_info
+                            .siblings
+                            .iter()
+                            .map(|s| s.rfilename.as_str())
+                            .filter(|name| is_main_gguf(name))
+                            .collect();
+                        let hint = if available.is_empty() {
+                            "the repo contains no GGUF files".to_owned()
+                        } else {
+                            format!(
+                                "available variants: {}. Select one in the modelfile, e.g. `FROM {}:<variant>`",
+                                available.join(", "),
+                                modelname
+                            )
+                        };
+                        return Err(anyhow!(
+                            "No GGUF matching quant '{}' found in {} ({})",
+                            quant,
+                            modelname,
+                            hint
+                        ));
+                    }
 
                     for sibling in filtered_siblings {
                         if repo.get(&sibling.rfilename).await.is_err() {
@@ -62,6 +104,13 @@ pub async fn snapshot_download(modelname: &str) -> Result<()> {
     Ok(())
 }
 
+/// True for gguf files that can serve as the main model (excludes the
+/// mmproj vision encoder and MTP draft heads, which are never main models).
+fn is_main_gguf(filename: &str) -> bool {
+    let name = filename.to_lowercase();
+    name.ends_with(".gguf") && !name.contains("mmproj") && !name.contains("mtp")
+}
+
 fn format_hf_api_error(api_error: ApiError) -> String {
     match api_error {
         ApiError::RequestError(err) => err.to_string(),
@@ -71,4 +120,15 @@ fn format_hf_api_error(api_error: ApiError) -> String {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::is_main_gguf;
+
+    #[test]
+    fn test_is_main_gguf() {
+        assert!(is_main_gguf("gemma-4-12b-it-Q4_K_M.gguf"));
+        assert!(is_main_gguf("Some-Model-Q8_0.GGUF"));
+        assert!(!is_main_gguf("mmproj-F16.gguf"));
+        assert!(!is_main_gguf("mtp-gemma-4-12b-it.gguf"));
+        assert!(!is_main_gguf("config.json"));
+    }
+}

--- a/tiles/src/utils/hf_model_downloader.rs
+++ b/tiles/src/utils/hf_model_downloader.rs
@@ -18,14 +18,7 @@ pub async fn pull_model(model_name: &str, quant: Option<&str>) -> Result<()> {
 
 pub async fn snapshot_download(modelname: &str, quant: Option<&str>) -> Result<()> {
     let quant = quant.unwrap_or(DEFAULT_QUANT);
-    let metadata_patterns = [
-        ".json",
-        ".txt",
-        ".safetensors",
-        ".md",
-        ".gitattributes",
-        "LICENSE",
-    ];
+    let metadata_patterns = [".json", ".txt", ".md", ".gitattributes", "LICENSE"];
     let quant_gguf = format!("{}.gguf", quant.to_lowercase());
     let allow_patterns: Vec<String> = metadata_patterns
         .iter()

--- a/toolchain.toml
+++ b/toolchain.toml
@@ -3,9 +3,7 @@
 
 
 [embedded-tools]
-pi = "v0.83.0"
-# fork of tiles-pi
-tiles-pi="v0.67.68"
+pi = "v0.84.2"
 sqlcipher = "4.10.0"
 
 [dev-tools]


### PR DESCRIPTION
## Summary:
Tiles now ships with unsloth/gemma-4-12b-it-GGUF (Q4_K_M) as the default model, and users can pick any quantization directly in the modelfile.

## What changed:
- Default model switched to Gemma 4 12B: new default modelfile modelfiles/gemma-4-12b-gguf
- Quantization selection via modelfile: ollama-style syntax FROM unsloth/gemma-4-12b-it-GGUF:Q8_0. No tag = Q4_K_M default. The parser (tilekit) now splits the repo and quant, and the downloader fetches only the requested variant
- MTP speculative decoding auto-enables: if the model ships an MTP head (gemma does), llama-server uses it automatically for faster inference. Disable with [llama] mtp = false

- Offline installer updated: pkg/build_model.sh now fully scripted: downloads/bundles gemma Q4_K_M + MTP head, tars and splits for pkgbuild.

- Removed unused mem-agent/memory-mode flag
- Pi updated to v0.84.2 (upstream badlogic/pi-mono), removed stale tiles-pi fork references
- Notarization fix: Pi's bundled .node native modules are now signed (v0.84.x ships new unsigned modules that broke notarization)