### PR TITLE
Add vulkan backend support

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,8 +1,8 @@
 name: Linux Release
 
-# Builds the Linux (x86_64) tarball whenever any tag is pushed
-# (stable, rc, nightly) and attaches it to the tag's GitHub Release.
-# install.sh resolves assets by pattern tiles-v*-{arch}-linux.tar.gz.
+# Builds the Linux (x86_64) CUDA and Vulkan tarballs whenever any tag is pushed
+# (stable, rc, nightly) and attaches them to the tag's GitHub Release.
+# Vulkan assets add a -vulkan suffix to the existing Linux filename.
 # Can also be run manually (Actions tab -> Run workflow) from a branch
 # (artifacts land on the run page) or from a tag ref (uploads into the
 # release for that tag, e.g. re-publishing into an existing 0.4.17).
@@ -21,6 +21,11 @@ env:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        backend: [cuda, vulkan]
+    env:
+      TILES_LLAMA_BACKEND: ${{ matrix.backend }}
     steps:
       # persist-credentials: false — nothing here pushes git changes, so the
       # write-capable token has no business sitting in .git/config for the
@@ -59,28 +64,44 @@ jobs:
           curl -fL -o pi-linux-x64.tar.gz \
             "https://github.com/badlogic/pi-mono/releases/download/${VERSION}/pi-linux-x64.tar.gz"
 
-      - name: Fetch llama-server (latest ai-dock CUDA prebuilt)
+      - name: Fetch llama-server
         run: ./scripts/fetch_llama_server.sh
 
       - name: Build bundle
         run: just bundle
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.backend }}-tarball
+          path: dist/tiles-v*.tar.gz
+          if-no-files-found: error
+
+  publish-linux:
+    runs-on: ubuntu-latest
+    needs: build-linux
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: linux-*-tarball
+          path: dist
+          merge-multiple: true
+
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum tiles-v*-x86_64-linux.tar.gz > checksums.txt
+          sha256sum tiles-v*.tar.gz > checksums.txt
           cat checksums.txt
 
-      # Manual (non-tag) runs: attach the bundle to the workflow run page
-      # instead of touching any release.
-      - name: Upload build artifacts
+      # Manual (non-tag) runs: the per-backend tarballs already land on the run
+      # page from build-linux; only the checksums are unique to this job.
+      - name: Upload checksums
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@v4
         with:
-          name: linux-tarball
-          path: |
-            dist/tiles-v*-x86_64-linux.tar.gz
-            dist/checksums.txt
+          name: linux-checksums
+          path: dist/checksums.txt
           if-no-files-found: error
 
       # Creates the release if missing, or uploads into the tag's existing
@@ -91,7 +112,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            dist/tiles-v*-x86_64-linux.tar.gz
+            dist/tiles-v*.tar.gz
             dist/checksums.txt
           fail_on_unmatched_files: true
         env:

--- a/justfile
+++ b/justfile
@@ -16,11 +16,11 @@ serve:
     server/.venv/bin/python3 -m server.main
     # uv run --project server python -m server.main
 
-bundle:
-    ./scripts/bundler.sh
+bundle *ARGS:
+    ./scripts/bundler.sh {{ARGS}}
 
-install:
-    ./scripts/install.sh
+install *ARGS:
+    ./scripts/install.sh {{ARGS}}
 
 bundle_pkg:
     ./pkg/build.sh

--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -16,10 +16,14 @@ VERSION=$(grep '^version' tiles/Cargo.toml | head -1 | awk -F'"' '{print $2}')
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 case "${OS}" in
-  darwin) STACK_SPEC="server/stack/macos/venvstacks.toml" ;;
-  linux) STACK_SPEC="server/stack/linux/venvstacks.toml" ;;
+  darwin) STACK_SPEC="server/stack/macos/venvstacks.toml"; LLAMA_BACKEND="${TILES_LLAMA_BACKEND:-metal}" ;;
+  linux) STACK_SPEC="server/stack/linux/venvstacks.toml"; LLAMA_BACKEND="${TILES_LLAMA_BACKEND:-cuda}" ;;
   *) echo "Unsupported OS for venvstack bundle: ${OS}" >&2; exit 1 ;;
 esac
+[[ "${OS}:${LLAMA_BACKEND}" == "darwin:metal" \
+  || "${OS}:${LLAMA_BACKEND}" == "linux:cuda" \
+  || "${OS}:${LLAMA_BACKEND}" == "linux:vulkan" ]] \
+  || { echo "Unsupported llama backend ${LLAMA_BACKEND} on ${OS}" >&2; exit 1; }
 case "${ARCH}" in
   x86_64) PI_ARCH="x64" ;;
   aarch64|arm64) PI_ARCH="arm64" ;;
@@ -29,7 +33,12 @@ PI_TARBALL="pi-${OS}-${PI_ARCH}.tar.gz"
 
 # Name for final tar.gz 
 
+# Linux ships one tarball per inference backend, so the backend is part of the
+# name. macOS stays unsuffixed: metal is the only backend there.
 OUT_NAME="${BINARY_NAME}-v${VERSION}-${ARCH}-${OS}"
+if [[ "${OS}" == "linux" ]]; then
+  OUT_NAME="${OUT_NAME}-${LLAMA_BACKEND}"
+fi
 
 echo "🚀 Building ${BINARY_NAME} (${TARGET} mode)..."
 

--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -11,19 +11,35 @@ SERVER_DIR="server"
 # cargo build mode for production
 TARGET="release"
 
-# Fetching the tiles binary version from its cargo.toml version 
+# Backend precedence: --backend flag, then TILES_LLAMA_BACKEND, then the OS default.
+BACKEND_FLAG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --backend)
+      [[ $# -ge 2 ]] || { echo "--backend requires a value" >&2; exit 1; }
+      BACKEND_FLAG="$2"
+      shift 2
+      ;;
+    *) echo "Usage: $0 [--backend cuda|vulkan]" >&2; exit 1 ;;
+  esac
+done
+
+# Fetching the tiles binary version from its cargo.toml version
 VERSION=$(grep '^version' tiles/Cargo.toml | head -1 | awk -F'"' '{print $2}')
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 case "${OS}" in
-  darwin) STACK_SPEC="server/stack/macos/venvstacks.toml"; LLAMA_BACKEND="${TILES_LLAMA_BACKEND:-metal}" ;;
-  linux) STACK_SPEC="server/stack/linux/venvstacks.toml"; LLAMA_BACKEND="${TILES_LLAMA_BACKEND:-cuda}" ;;
+  darwin) STACK_SPEC="server/stack/macos/venvstacks.toml"; LLAMA_BACKEND="${BACKEND_FLAG:-${TILES_LLAMA_BACKEND:-metal}}" ;;
+  linux) STACK_SPEC="server/stack/linux/venvstacks.toml"; LLAMA_BACKEND="${BACKEND_FLAG:-${TILES_LLAMA_BACKEND:-cuda}}" ;;
   *) echo "Unsupported OS for venvstack bundle: ${OS}" >&2; exit 1 ;;
 esac
 [[ "${OS}:${LLAMA_BACKEND}" == "darwin:metal" \
   || "${OS}:${LLAMA_BACKEND}" == "linux:cuda" \
   || "${OS}:${LLAMA_BACKEND}" == "linux:vulkan" ]] \
   || { echo "Unsupported llama backend ${LLAMA_BACKEND} on ${OS}" >&2; exit 1; }
+
+# fetch_llama_server.sh reads the backend from the environment.
+export TILES_LLAMA_BACKEND="${LLAMA_BACKEND}"
 case "${ARCH}" in
   x86_64) PI_ARCH="x64" ;;
   aarch64|arm64) PI_ARCH="arm64" ;;
@@ -40,7 +56,7 @@ if [[ "${OS}" == "linux" ]]; then
   OUT_NAME="${OUT_NAME}-${LLAMA_BACKEND}"
 fi
 
-echo "🚀 Building ${BINARY_NAME} (${TARGET} mode)..."
+echo "🚀 Building ${BINARY_NAME} (${TARGET} mode, ${LLAMA_BACKEND} backend)..."
 
 cargo build -p tiles --${TARGET}
 

--- a/scripts/fetch_llama_server.sh
+++ b/scripts/fetch_llama_server.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Provision the llama-server binary that powers Tiles inference.
-#   - Linux: download a prebuilt CUDA binary from ai-dock/llama.cpp-cuda.
-#     Default is the latest release; pin with LLAMA_CPP_TAG=bXXXX.
+#   - Linux: download a prebuilt CUDA or Vulkan binary.
+#     CUDA defaults to the latest ai-dock release; Vulkan defaults to b9867.
 #   - macOS: download the official prebuilt Metal release from llama.cpp.
 #
-# Linux (CUDA-only): the downloaded binary links against CUDA 12.8 runtime
+# Linux (CUDA): the downloaded binary links against CUDA 12.8 runtime
 # libraries, which must be present on the host for llama-server to start.
 #
 # Environment variables:
-#   LLAMA_CPP_TAG        Pin a specific release tag (e.g. b10276). If unset,
-#                        the latest ai-dock/llama.cpp-cuda release is used.
+#   TILES_LLAMA_BACKEND  Linux backend: cuda (default) or vulkan.
+#   LLAMA_CPP_TAG        Pin a specific release tag (e.g. b10276).
 #   TILES_CUDA_VERSION   CUDA version suffix for the asset (default: 12.8).
 #                        Only used when LLAMA_CPP_TAG is pinned; the auto-
 #                        latest path reads the version from the asset name.
@@ -18,16 +18,28 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_DIR="${ROOT}/server/bin"
+OS="$(uname -s)"
+
+if [[ "${OS}" == "Darwin" ]]; then
+  BACKEND="${TILES_LLAMA_BACKEND:-metal}"
+  [[ "${BACKEND}" == "metal" ]] || { echo "Unsupported macOS llama backend: ${BACKEND}" >&2; exit 1; }
+elif [[ "${OS}" == "Linux" ]]; then
+  BACKEND="${TILES_LLAMA_BACKEND:-cuda}"
+  [[ "${BACKEND}" == "cuda" || "${BACKEND}" == "vulkan" ]] || { echo "Unsupported Linux llama backend: ${BACKEND}" >&2; exit 1; }
+else
+  echo "Unsupported OS: ${OS}" >&2
+  exit 1
+fi
 
 mkdir -p "${OUT_DIR}"
 
 # Reuse an already-provisioned binary. Set FORCE_LLAMA_FETCH=1 to re-download.
-if [[ -x "${OUT_DIR}/llama-server" && "${FORCE_LLAMA_FETCH:-}" != "1" ]]; then
+if [[ -x "${OUT_DIR}/llama-server" && -f "${OUT_DIR}/.llama-backend" \
+  && "$(<"${OUT_DIR}/.llama-backend")" == "${BACKEND}" \
+  && "${FORCE_LLAMA_FETCH:-}" != "1" ]]; then
   echo "llama-server already present at ${OUT_DIR}/llama-server; skipping fetch (set FORCE_LLAMA_FETCH=1 to force)."
   exit 0
 fi
-
-OS="$(uname -s)"
 
 # ---------------------------------------------------------------------------
 # macOS: official prebuilt Metal release from ggml-org/llama.cpp.
@@ -59,29 +71,29 @@ if [[ "${OS}" == "Darwin" ]]; then
   cp -a "${BIN_DIR}/"*.dylib "${OUT_DIR}/" 2>/dev/null || true
   cp -a "${BIN_DIR}/"*.metal* "${OUT_DIR}/" 2>/dev/null || true
   chmod +x "${OUT_DIR}/llama-server"
+  printf '%s\n' "${BACKEND}" > "${OUT_DIR}/.llama-backend"
   rm -rf "${TMP}"
   echo "Installed ${OUT_DIR}/llama-server (macOS Metal, ${LLAMA_CPP_TAG})"
   exit 0
 fi
 
-if [[ "${OS}" != "Linux" ]]; then
-  echo "Unsupported OS: ${OS}" >&2
-  exit 1
-fi
-
 # ---------------------------------------------------------------------------
-# Linux: prebuilt CUDA binary from ai-dock/llama.cpp-cuda.
+# Linux: prebuilt CUDA or Vulkan binary.
 # --------------------------------------------------------------------------
 ARCH="$(uname -m)"
 case "${ARCH}" in
-  x86_64)  ASSET_ARCH="amd64" ;;
-  aarch64|arm64) ASSET_ARCH="arm64" ;;
+  x86_64)  ASSET_ARCH="amd64"; OFFICIAL_ARCH="x64" ;;
+  aarch64|arm64) ASSET_ARCH="arm64"; OFFICIAL_ARCH="arm64" ;;
   *) echo "Unsupported Linux architecture: ${ARCH}" >&2; exit 1 ;;
 esac
 
 API_URL="https://api.github.com/repos/ai-dock/llama.cpp-cuda/releases/latest"
 
-if [[ -n "${LLAMA_CPP_TAG:-}" ]]; then
+if [[ "${BACKEND}" == "vulkan" ]]; then
+  TAG="${LLAMA_CPP_TAG:-b9867}"
+  ASSET="llama-${TAG}-bin-ubuntu-vulkan-${OFFICIAL_ARCH}.tar.gz"
+  URL="https://github.com/ggml-org/llama.cpp/releases/download/${TAG}/${ASSET}"
+elif [[ -n "${LLAMA_CPP_TAG:-}" ]]; then
   # Pinned tag: construct the URL directly. CUDA version comes from the
   # override (default 12.8), since the API isn't queried.
   CUDA_VERSION="${TILES_CUDA_VERSION:-12.8}"
@@ -115,7 +127,7 @@ fi
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
-echo "Downloading ${ASSET} (prebuilt CUDA, ${TAG})"
+echo "Downloading ${ASSET} (prebuilt ${BACKEND}, ${TAG})"
 curl -fL -o "${TMP}/${ASSET}" "${URL}"
 tar -xzf "${TMP}/${ASSET}" -C "${TMP}"
 
@@ -124,13 +136,15 @@ if [[ -z "${SERVER_BIN}" ]]; then
   echo "llama-server not found inside ${ASSET}" >&2
   exit 1
 fi
-  BIN_DIR="$(dirname "${SERVER_BIN}")"
-  cp "${SERVER_BIN}" "${OUT_DIR}/llama-server"
-  # Bring along bundled shared libs (libggml*.so etc.) if shipped next to it.
-  # cp -a preserves the .so -> .so.N -> .so.N.M.K symlink chain; a plain cp
-  # dereferences it into 3 real copies of every library (3x 162 MB for
-  # libggml-cuda.so with the ai-dock universal CUDA build).
-  cp -a "${BIN_DIR}/"*.so* "${OUT_DIR}/" 2>/dev/null || true
+BIN_DIR="$(dirname "${SERVER_BIN}")"
+rm -f "${OUT_DIR}/llama-server" "${OUT_DIR}/"*.so* "${OUT_DIR}/.llama-backend"
+cp "${SERVER_BIN}" "${OUT_DIR}/llama-server"
+# Bring along bundled shared libs (libggml*.so etc.) if shipped next to it.
+# cp -a preserves the shared-library symlink chain.
+cp -a "${BIN_DIR}/"*.so* "${OUT_DIR}/" 2>/dev/null || true
 chmod +x "${OUT_DIR}/llama-server"
-echo "Installed ${OUT_DIR}/llama-server (Linux CUDA prebuilt, ${TAG})"
-echo "Note: requires CUDA ${CUDA_VERSION} runtime libraries on the host to run."
+printf '%s\n' "${BACKEND}" > "${OUT_DIR}/.llama-backend"
+echo "Installed ${OUT_DIR}/llama-server (Linux ${BACKEND} prebuilt, ${TAG})"
+if [[ "${BACKEND}" == "cuda" ]]; then
+  echo "Note: requires CUDA ${CUDA_VERSION} runtime libraries on the host to run."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,6 +29,7 @@ REPO="tilesprivacy/tiles"
 VERSION="0.4.17"
 DEV="false"
 NIGHTLY="false"
+BACKEND="auto"
 
 log() { echo -e "\033[1;36m$*\033[0m"; }
 err() { echo -e "\033[1;31m$*\033[0m" >&2; exit 1; }
@@ -37,22 +38,23 @@ warn() {
 }
 
 usage() {
-  echo "Usage: curl -LsSf https://www.tiles.run/install.sh | sh -s -- [--nightly]"
-  echo "   or: scripts/install.sh [--dev] [--nightly]"
+  echo "Usage: curl -LsSf https://www.tiles.run/install.sh | sh -s -- [--nightly] [--backend BACKEND]"
+  echo "   or: scripts/install.sh [--dev] [--nightly] [--backend BACKEND]"
   echo ""
   echo "  --dev       Install from a local dist/*.tar.gz instead of GitHub"
   echo "  --nightly   Install the latest nightly GitHub release"
-  echo "              (e.g. tiles-v0.4.17-x86_64-linux.tar.gz)"
+  echo "              (e.g. tiles-v0.4.17-x86_64-linux-cuda.tar.gz)"
+  echo "  --backend   Linux inference backend: auto (default), cuda, or vulkan"
 }
 
 # Resolve the newest GitHub nightly release that has a tarball for this platform.
-# Accepts any tiles-v*-${ARCH}-${OS}.tar.gz on that release (asset version may
-# differ from the tag, e.g. tag 0.4.17-nightly.2 shipping a nightly.1 linux tarball).
+# The asset version may differ from the tag, e.g. tag 0.4.17-nightly.2 shipping
+# a nightly.1 Linux tarball.
 # Sets RELEASE_TAG, VERSION (for logs), and RELEASE_ASSET (exact filename).
 resolve_nightly_version() {
   local api_url="https://api.github.com/repos/${REPO}/releases?per_page=30"
   local releases_json tag tags release_json asset
-  local platform="${ARCH}-${OS}"
+  local platform="${ARCH}-${OS}${ASSET_SUFFIX}"
 
   releases_json="$(curl -fsSL "${api_url}")" || err "Failed to query GitHub releases for ${REPO}."
 
@@ -92,24 +94,30 @@ EOF
   err "No nightly found for ${platform} (no matching tiles-v*-${platform}.tar.gz on GitHub)."
 }
 
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --dev|-dev)
       DEV="true"
       ;;
     --nightly|-nightly)
       NIGHTLY="true"
       ;;
+    --backend)
+      [[ $# -ge 2 ]] || err "--backend requires a value."
+      BACKEND="$2"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
       ;;
     *)
-      echo "Unknown argument: $arg" >&2
+      echo "Unknown argument: $1" >&2
       usage >&2
       exit 1
       ;;
   esac
+  shift
 done
 
 if [[ "${DEV}" == "true" && "${NIGHTLY}" == "true" ]]; then
@@ -118,6 +126,56 @@ fi
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
+
+if [[ "${OS}" == "linux" ]]; then
+  [[ "${BACKEND}" == "auto" || "${BACKEND}" == "cuda" || "${BACKEND}" == "vulkan" ]] \
+    || err "Unsupported Linux backend: ${BACKEND}."
+
+  # checks for NVIDIA userspace drivers and enumerates GPU availability
+  # then checks if CUDA runtime is availabile
+  if [[ "${BACKEND}" == "auto" ]]; then
+    CUDA_RUNTIME="false"
+    if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+      if command -v ldconfig >/dev/null 2>&1 \
+        && ldconfig -p 2>/dev/null | grep -E 'libcudart\.so\.12([[:space:]]|$)' >/dev/null; then
+        CUDA_RUNTIME="true"
+      # ldconfig covers only the system cache, not pip/conda/tarball installs.
+      # manually check paths
+      elif [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+        IFS=':' read -r -a LIBRARY_PATHS <<< "${LD_LIBRARY_PATH}"
+        for LIBRARY_PATH in "${LIBRARY_PATHS[@]}"; do
+          [[ -n "${LIBRARY_PATH}" ]] || LIBRARY_PATH="."
+          if [[ -e "${LIBRARY_PATH}/libcudart.so.12" ]]; then
+            CUDA_RUNTIME="true"
+            break
+          fi
+        done
+      fi
+    fi
+
+    if [[ "${CUDA_RUNTIME}" == "true" ]]; then
+      BACKEND="cuda"
+    else
+      BACKEND="vulkan"
+    fi
+    log "Auto-selected ${BACKEND} inference backend."
+  fi
+elif [[ "${BACKEND}" != "auto" ]]; then
+  err "Backend ${BACKEND} is not supported on ${OS}."
+else
+  BACKEND="metal"
+fi
+
+if [[ "${BACKEND}" == "vulkan" ]] \
+  && ! ldconfig -p 2>/dev/null | grep 'libvulkan\.so\.1' >/dev/null; then
+  warn "⚠️  No Vulkan loader found (libvulkan.so.1)."
+  warn "    Install your distro's vulkan-loader package."
+fi
+
+# Linux assets carry the backend in their name; macOS assets do not (metal is
+# the only backend there). BACKEND is already resolved from "auto" by here.
+ASSET_SUFFIX=""
+[[ "${OS}" == "linux" ]] && ASSET_SUFFIX="-${BACKEND}"
 
 if [[ "${OS}" == "linux" && "$(id -u)" != "0" ]]; then
   INSTALL_DIR="${HOME}/.local/bin"
@@ -133,7 +191,7 @@ PI_DIR="${LIB_DIR}/pi"
 
 TMPDIR="$(mktemp -d)"
 RELEASE_TAG="${VERSION}"
-RELEASE_ASSET="tiles-v${VERSION}-${ARCH}-${OS}.tar.gz"
+RELEASE_ASSET="tiles-v${VERSION}-${ARCH}-${OS}${ASSET_SUFFIX}.tar.gz"
 
 if [[ "${NIGHTLY}" == "true" ]]; then
   resolve_nightly_version
@@ -156,7 +214,7 @@ else
   else
     LOCAL_TARBALL=""
     shopt -s nullglob
-    LOCAL_TARBALLS=(dist/tiles-v*-"${ARCH}"-"${OS}".tar.gz)
+    LOCAL_TARBALLS=(dist/tiles-v*-"${ARCH}"-"${OS}${ASSET_SUFFIX}".tar.gz)
     shopt -u nullglob
     for candidate in "${LOCAL_TARBALLS[@]}"; do
       if [[ -z "${LOCAL_TARBALL}" || "${candidate}" -nt "${LOCAL_TARBALL}" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,10 +160,11 @@ if [[ "${OS}" == "linux" ]]; then
     fi
     log "Auto-selected ${BACKEND} inference backend."
   fi
-elif [[ "${BACKEND}" != "auto" ]]; then
-  err "Backend ${BACKEND} is not supported on ${OS}."
-else
+elif [[ "${OS}" == "darwin" ]]; then
+  [[ "${BACKEND}" == "auto" ]] || err "Backend ${BACKEND} is not supported on ${OS}."
   BACKEND="metal"
+else
+  err "Unsupported OS: ${OS}."
 fi
 
 if [[ "${BACKEND}" == "vulkan" ]] \


### PR DESCRIPTION
Updates the release workflow, scripts and install.sh

Adds 2 linux llama.cpp backend release tarballs:
`tiles-v*-x86_64-linux-cuda.tar.gz`
`tiles-v*-x86_64-linux-vulkan.tar.gz`

install.sh auto-infers backend if cuda libraries are present

