### PR TITLE
fix(atproto): avoid blocking OAuth callback & print login URL

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Install native dependencies
@@ -45,7 +45,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.91.0
+          toolchain: 1.95.0
 
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config

--- a/tiles/src/core/account/atproto.rs
+++ b/tiles/src/core/account/atproto.rs
@@ -138,6 +138,11 @@ pub async fn login(conn: &Dbconn, handle: &str) -> Result<()> {
         .await
         .inspect_err(|_| eprintln!("Failed to generate authorization url"))?;
 
+    println!(
+        "\nIf the browser doesn't open automatically, open this URL:\n\n{}\n",
+        url
+    );
+
     let program_name = cfg_select! {
         target_os = "macos" => {
             "open"
@@ -158,18 +163,18 @@ pub async fn login(conn: &Dbconn, handle: &str) -> Result<()> {
             url
         )
     } else {
-        if let Ok(mut program) = Command::new(program_name).arg(&url).spawn() {
-            if program.wait().is_err() {
+        match Command::new(program_name).arg(&url).spawn() {
+            Ok(mut child) => {
+                drop(std::thread::spawn(move || {
+                    let _ = child.wait();
+                }));
+            }
+            Err(_) => {
                 println!(
-                    "Failed to open the url automatically, Please open the url in any browser: {}",
+                    "Failed to open the url automatically, Please open the url\n{} in any browser",
                     url
                 )
             }
-        } else {
-            println!(
-                "Failed to open the url automatically, Please open the url\n{} in any browser",
-                url
-            )
         }
     };
 
@@ -206,7 +211,7 @@ pub async fn login(conn: &Dbconn, handle: &str) -> Result<()> {
         };
 
         upsert_auth_data(&conn.common, &auth_data)?;
-        println!("LoggedIn successfully as {}", handle);
+        println!("LoggedIn successfully as {}\n", handle);
         Ok(())
     } else {
         Err(anyhow!(

--- a/tiles/src/core/account/atproto.rs
+++ b/tiles/src/core/account/atproto.rs
@@ -157,26 +157,13 @@ pub async fn login(conn: &Dbconn, handle: &str) -> Result<()> {
 
     // adding this override due to  clippy not playing good w macro above
     #[allow(clippy::const_is_empty)]
-    if program_name.is_empty() {
-        println!(
-            "Failed to open the url automatically, Please open the url in any browser {}",
-            url
-        )
-    } else {
-        match Command::new(program_name).arg(&url).spawn() {
-            Ok(mut child) => {
-                drop(std::thread::spawn(move || {
-                    let _ = child.wait();
-                }));
-            }
-            Err(_) => {
-                println!(
-                    "Failed to open the url automatically, Please open the url\n{} in any browser",
-                    url
-                )
-            }
+    if !program_name.is_empty() {
+        if let Ok(mut child) = Command::new(program_name).arg(&url).spawn() {
+            drop(std::thread::spawn(move || {
+                let _ = child.wait();
+            }));
         }
-    };
+    }
 
     let (callback_tx, callback_rx) = oneshot::channel();
 

--- a/tiles/src/core/account/atproto.rs
+++ b/tiles/src/core/account/atproto.rs
@@ -22,8 +22,8 @@ use log::info;
 use reqwest::Client;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, process::Command, sync::Arc, time::Duration};
-use tokio::sync::oneshot;
+use std::{fmt::Debug, sync::Arc, time::Duration};
+use tokio::{process::Command, sync::oneshot};
 
 use std::error::Error;
 
@@ -157,12 +157,13 @@ pub async fn login(conn: &Dbconn, handle: &str) -> Result<()> {
 
     // adding this override due to  clippy not playing good w macro above
     #[allow(clippy::const_is_empty)]
-    if !program_name.is_empty() {
-        if let Ok(mut child) = Command::new(program_name).arg(&url).spawn() {
-            drop(std::thread::spawn(move || {
-                let _ = child.wait();
-            }));
-        }
+    if !program_name.is_empty()
+        && let Ok(mut child) = Command::new(program_name).arg(&url).spawn()
+    {
+        #[allow(clippy::let_underscore_future)]
+        let _ = tokio::spawn(async move {
+            let _ = child.wait().await;
+        });
     }
 
     let (callback_tx, callback_rx) = oneshot::channel();


### PR DESCRIPTION
- `xdg-open` may block indefinitely when launching a program, avoids waiting on it and blocking the program
- prints the login URL in case open command fails
