### PR TITLE
fix(updater): preserve installation paths

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,6 +30,8 @@ VERSION="0.4.18"
 DEV="false"
 NIGHTLY="false"
 BACKEND="auto"
+INSTALL_DIR_OVERRIDE=""
+LIB_DIR_OVERRIDE=""
 
 log() { echo -e "\033[1;36m$*\033[0m"; }
 err() { echo -e "\033[1;31m$*\033[0m" >&2; exit 1; }
@@ -38,13 +40,15 @@ warn() {
 }
 
 usage() {
-  echo "Usage: curl -LsSf https://www.tiles.run/install.sh | sh -s -- [--nightly] [--backend BACKEND]"
-  echo "   or: scripts/install.sh [--dev] [--nightly] [--backend BACKEND]"
+  echo "Usage: curl -LsSf https://www.tiles.run/install.sh | sh -s -- [OPTIONS]"
+  echo "   or: scripts/install.sh [OPTIONS]"
   echo ""
-  echo "  --dev       Install from a local dist/*.tar.gz instead of GitHub"
-  echo "  --nightly   Install the latest nightly GitHub release"
-  echo "              (e.g. tiles-v0.4.17-x86_64-linux-cuda.tar.gz)"
-  echo "  --backend   Linux inference backend: auto (default), cuda, or vulkan"
+  echo "  --dev                Install from a local dist/*.tar.gz instead of GitHub"
+  echo "  --nightly            Install the latest nightly GitHub release"
+  echo "                       (e.g. tiles-v0.4.17-x86_64-linux-cuda.tar.gz)"
+  echo "  --backend BACKEND    Linux inference backend: auto (default), cuda, or vulkan"
+  echo "  --install-dir PATH   Override the binary installation directory"
+  echo "  --lib-dir PATH       Override the runtime installation directory"
 }
 
 # Resolve the newest GitHub nightly release that has a tarball for this platform.
@@ -105,6 +109,18 @@ while [[ $# -gt 0 ]]; do
     --backend)
       [[ $# -ge 2 ]] || err "--backend requires a value."
       BACKEND="$2"
+      shift
+      ;;
+    --install-dir)
+      [[ $# -ge 2 ]] || err "--install-dir requires a value."
+      [[ -n "$2" ]] || err "--install-dir requires a non-empty value."
+      INSTALL_DIR_OVERRIDE="$2"
+      shift
+      ;;
+    --lib-dir)
+      [[ $# -ge 2 ]] || err "--lib-dir requires a value."
+      [[ -n "$2" ]] || err "--lib-dir requires a non-empty value."
+      LIB_DIR_OVERRIDE="$2"
       shift
       ;;
     -h|--help)
@@ -185,6 +201,9 @@ else
   INSTALL_DIR="/usr/local/bin"
   LIB_DIR="/usr/local/share/tiles"
 fi
+
+[[ -n "${INSTALL_DIR_OVERRIDE}" ]] && INSTALL_DIR="${INSTALL_DIR_OVERRIDE}"
+[[ -n "${LIB_DIR_OVERRIDE}" ]] && LIB_DIR="${LIB_DIR_OVERRIDE}"
 
 SERVER_DIR="${LIB_DIR}/server"         # Python server folder
 MODELFILE_DIR="${LIB_DIR}/modelfiles"  # Modelfile server folder

--- a/tiles/Cargo.toml
+++ b/tiles/Cargo.toml
@@ -49,7 +49,7 @@ iroh-mdns-address-lookup = "0.4.0"
 tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["user", "process"] }
+nix = { version = "0.29", features = ["fs", "user", "process"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }

--- a/tiles/src/utils/installer.rs
+++ b/tiles/src/utils/installer.rs
@@ -40,7 +40,7 @@ pub struct UpdateInfo {
 struct UpdateInstallLayout {
     install_dir: PathBuf,
     lib_dir: PathBuf,
-    is_system: bool,
+    is_system_path: bool,
 }
 
 fn resolve_update_install_layout(
@@ -54,7 +54,7 @@ fn resolve_update_install_layout(
         return Ok(UpdateInstallLayout {
             install_dir: portable_dir.to_path_buf(),
             lib_dir: portable_dir.to_path_buf(),
-            is_system: false,
+            is_system_path: false,
         });
     }
 
@@ -62,7 +62,7 @@ fn resolve_update_install_layout(
         return Ok(UpdateInstallLayout {
             install_dir: PathBuf::from(SYSTEM_BIN_DIR),
             lib_dir: PathBuf::from(SYSTEM_LIB_DIR),
-            is_system: true,
+            is_system_path: true,
         });
     }
 
@@ -73,7 +73,7 @@ fn resolve_update_install_layout(
         return Ok(UpdateInstallLayout {
             install_dir: install_dir.to_path_buf(),
             lib_dir: user_lib_dir.to_path_buf(),
-            is_system: false,
+            is_system_path: false,
         });
     }
 
@@ -87,15 +87,15 @@ fn nearest_existing_ancestor(path: &Path) -> Option<&Path> {
     path.ancestors().find(|ancestor| ancestor.exists())
 }
 
-fn destination_is_writable(path: &Path) -> bool {
+fn is_destination_writable(path: &Path) -> bool {
     nearest_existing_ancestor(path).is_some_and(|ancestor| {
         ancestor.is_dir() && access(ancestor, AccessFlags::W_OK | AccessFlags::X_OK).is_ok()
     })
 }
 
-fn update_needs_elevation(
+fn resolve_update_elevation(
     layout: &UpdateInstallLayout,
-    is_writable: impl Fn(&Path) -> bool,
+    check_writable: impl Fn(&Path) -> bool,
 ) -> Result<bool> {
     let mut destinations = vec![layout.install_dir.as_path()];
     if layout.lib_dir != layout.install_dir {
@@ -104,12 +104,12 @@ fn update_needs_elevation(
 
     let unwritable = destinations
         .into_iter()
-        .filter(|path| !is_writable(path))
+        .filter(|path| !check_writable(path))
         .collect::<Vec<_>>();
     if unwritable.is_empty() {
         return Ok(false);
     }
-    if layout.is_system {
+    if layout.is_system_path {
         return Ok(true);
     }
 
@@ -143,7 +143,7 @@ pub async fn try_update(update_info: Option<UpdateInfo>) -> Result<String> {
             &provider.get_user_bin_path()?,
             &provider.get_data_dir()?,
         )?;
-        let needs_elevation = update_needs_elevation(&layout, destination_is_writable)?;
+        let needs_elevation = resolve_update_elevation(&layout, is_destination_writable)?;
         let mut curl_process = Command::new("curl")
             .arg("-fsSL")
             .arg("https://tiles.run/install.sh")
@@ -266,7 +266,7 @@ mod tests {
 
         assert_eq!(layout.install_dir, Path::new(SYSTEM_BIN_DIR));
         assert_eq!(layout.lib_dir, Path::new(SYSTEM_LIB_DIR));
-        assert!(layout.is_system);
+        assert!(layout.is_system_path);
     }
 
     #[test]
@@ -277,7 +277,7 @@ mod tests {
 
         assert_eq!(layout.install_dir, Path::new("/home/user/.local/bin"));
         assert_eq!(layout.lib_dir, user_lib);
-        assert!(!layout.is_system);
+        assert!(!layout.is_system_path);
     }
 
     #[test]
@@ -296,7 +296,7 @@ mod tests {
 
         assert_eq!(layout.install_dir, root.path());
         assert_eq!(layout.lib_dir, root.path());
-        assert!(!layout.is_system);
+        assert!(!layout.is_system_path);
     }
 
     #[test]
@@ -315,24 +315,24 @@ mod tests {
         let system_layout = UpdateInstallLayout {
             install_dir: PathBuf::from(SYSTEM_BIN_DIR),
             lib_dir: PathBuf::from(SYSTEM_LIB_DIR),
-            is_system: true,
+            is_system_path: true,
         };
-        assert!(!update_needs_elevation(&system_layout, |_| true).unwrap());
-        assert!(update_needs_elevation(&system_layout, |_| false).unwrap());
+        assert!(!resolve_update_elevation(&system_layout, |_| true).unwrap());
+        assert!(resolve_update_elevation(&system_layout, |_| false).unwrap());
 
         for layout in [
             UpdateInstallLayout {
                 install_dir: PathBuf::from("/home/user/.local/bin"),
                 lib_dir: PathBuf::from("/home/user/.local/share/tiles"),
-                is_system: false,
+                is_system_path: false,
             },
             UpdateInstallLayout {
                 install_dir: PathBuf::from("/opt/portable-tiles"),
                 lib_dir: PathBuf::from("/opt/portable-tiles"),
-                is_system: false,
+                is_system_path: false,
             },
         ] {
-            let error = update_needs_elevation(&layout, |_| false).unwrap_err();
+            let error = resolve_update_elevation(&layout, |_| false).unwrap_err();
             assert!(error.to_string().contains("will not use sudo"));
         }
     }
@@ -343,7 +343,7 @@ mod tests {
         let destination = root.path().join("missing/nested/directory");
 
         assert_eq!(nearest_existing_ancestor(&destination), Some(root.path()));
-        assert!(destination_is_writable(&destination));
+        assert!(is_destination_writable(&destination));
     }
 
     #[tokio::test]

--- a/tiles/src/utils/installer.rs
+++ b/tiles/src/utils/installer.rs
@@ -5,14 +5,22 @@
 //! install Tiles, just fetching the script and running as bash script from Rust.
 
 use std::{
+    env,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     time::Duration,
 };
 
 use anyhow::{Result, anyhow};
+use nix::unistd::{AccessFlags, access};
 use reqwest::{Client, header::HeaderMap};
 use semver::Version;
 use serde::Deserialize;
+
+use crate::utils::config::{
+    ConfigProvider, DefaultProvider, SYSTEM_BIN_DIR, SYSTEM_BIN_PATH, SYSTEM_LIB_DIR,
+    is_tiles_lib_dir,
+};
 
 const RELEASES_BASE_ENDPOINT: &str = "https://api.github.com";
 const RELEASES_REST_PATH: &str = "repos/tilesprivacy/tiles/releases/latest";
@@ -26,6 +34,93 @@ pub struct UpdateInfo {
     pub can_update: bool,
     pub latest_version: String,
     pub current_version: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct UpdateInstallLayout {
+    install_dir: PathBuf,
+    lib_dir: PathBuf,
+    is_system: bool,
+}
+
+fn resolve_update_install_layout(
+    current_exe: &Path,
+    user_bin_path: &Path,
+    user_lib_dir: &Path,
+) -> Result<UpdateInstallLayout> {
+    if let Some(portable_dir) = current_exe.parent()
+        && is_tiles_lib_dir(portable_dir)
+    {
+        return Ok(UpdateInstallLayout {
+            install_dir: portable_dir.to_path_buf(),
+            lib_dir: portable_dir.to_path_buf(),
+            is_system: false,
+        });
+    }
+
+    if current_exe == Path::new(SYSTEM_BIN_PATH) {
+        return Ok(UpdateInstallLayout {
+            install_dir: PathBuf::from(SYSTEM_BIN_DIR),
+            lib_dir: PathBuf::from(SYSTEM_LIB_DIR),
+            is_system: true,
+        });
+    }
+
+    if current_exe == user_bin_path {
+        let install_dir = user_bin_path
+            .parent()
+            .ok_or_else(|| anyhow!("Failed to resolve the user binary directory"))?;
+        return Ok(UpdateInstallLayout {
+            install_dir: install_dir.to_path_buf(),
+            lib_dir: user_lib_dir.to_path_buf(),
+            is_system: false,
+        });
+    }
+
+    Err(anyhow!(
+        "Cannot update Tiles from unsupported installation path {}",
+        current_exe.display()
+    ))
+}
+
+fn nearest_existing_ancestor(path: &Path) -> Option<&Path> {
+    path.ancestors().find(|ancestor| ancestor.exists())
+}
+
+fn destination_is_writable(path: &Path) -> bool {
+    nearest_existing_ancestor(path).is_some_and(|ancestor| {
+        ancestor.is_dir() && access(ancestor, AccessFlags::W_OK | AccessFlags::X_OK).is_ok()
+    })
+}
+
+fn update_needs_elevation(
+    layout: &UpdateInstallLayout,
+    is_writable: impl Fn(&Path) -> bool,
+) -> Result<bool> {
+    let mut destinations = vec![layout.install_dir.as_path()];
+    if layout.lib_dir != layout.install_dir {
+        destinations.push(layout.lib_dir.as_path());
+    }
+
+    let unwritable = destinations
+        .into_iter()
+        .filter(|path| !is_writable(path))
+        .collect::<Vec<_>>();
+    if unwritable.is_empty() {
+        return Ok(false);
+    }
+    if layout.is_system {
+        return Ok(true);
+    }
+
+    let paths = unwritable
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(anyhow!(
+        "Tiles installation path is not writable: {paths}. Fix its ownership or permissions and try again. The updater will not use sudo for a non-system installation because that would create root-owned files."
+    ))
 }
 
 pub async fn try_update(update_info: Option<UpdateInfo>) -> Result<String> {
@@ -42,14 +137,34 @@ pub async fn try_update(update_info: Option<UpdateInfo>) -> Result<String> {
         );
         Ok(msg)
     } else {
+        let provider = DefaultProvider;
+        let layout = resolve_update_install_layout(
+            &env::current_exe()?,
+            &provider.get_user_bin_path()?,
+            &provider.get_data_dir()?,
+        )?;
+        let needs_elevation = update_needs_elevation(&layout, destination_is_writable)?;
         let mut curl_process = Command::new("curl")
             .arg("-fsSL")
             .arg("https://tiles.run/install.sh")
             .stdout(Stdio::piped())
             .spawn()?;
 
-        let run_sh_cmd_status = Command::new("sudo")
-            .arg("sh")
+        let mut install_command = if needs_elevation {
+            let mut command = Command::new("sudo");
+            command.arg("sh");
+            command
+        } else {
+            Command::new("sh")
+        };
+
+        let run_sh_cmd_status = install_command
+            .arg("-s")
+            .arg("--")
+            .arg("--install-dir")
+            .arg(layout.install_dir)
+            .arg("--lib-dir")
+            .arg(layout.lib_dir)
             .stdin(
                 curl_process
                     .stdout
@@ -131,6 +246,7 @@ pub async fn get_latest_version(base_url: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{method, path},
@@ -138,6 +254,98 @@ mod tests {
 
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn resolves_system_update_layout() {
+        let layout = resolve_update_install_layout(
+            Path::new(SYSTEM_BIN_PATH),
+            Path::new("/home/user/.local/bin/tiles"),
+            Path::new("/home/user/.local/share/tiles"),
+        )
+        .unwrap();
+
+        assert_eq!(layout.install_dir, Path::new(SYSTEM_BIN_DIR));
+        assert_eq!(layout.lib_dir, Path::new(SYSTEM_LIB_DIR));
+        assert!(layout.is_system);
+    }
+
+    #[test]
+    fn resolves_user_update_layout() {
+        let user_bin = Path::new("/home/user/.local/bin/tiles");
+        let user_lib = Path::new("/home/user/custom-data/tiles");
+        let layout = resolve_update_install_layout(user_bin, user_bin, user_lib).unwrap();
+
+        assert_eq!(layout.install_dir, Path::new("/home/user/.local/bin"));
+        assert_eq!(layout.lib_dir, user_lib);
+        assert!(!layout.is_system);
+    }
+
+    #[test]
+    fn resolves_portable_update_layout() {
+        let root = tempdir().unwrap();
+        for component in ["server", "modelfiles", "pi"] {
+            std::fs::create_dir(root.path().join(component)).unwrap();
+        }
+
+        let layout = resolve_update_install_layout(
+            &root.path().join("tiles"),
+            Path::new("/home/user/.local/bin/tiles"),
+            Path::new("/home/user/.local/share/tiles"),
+        )
+        .unwrap();
+
+        assert_eq!(layout.install_dir, root.path());
+        assert_eq!(layout.lib_dir, root.path());
+        assert!(!layout.is_system);
+    }
+
+    #[test]
+    fn rejects_unknown_update_layout() {
+        let result = resolve_update_install_layout(
+            Path::new("/opt/tiles/bin/tiles"),
+            Path::new("/home/user/.local/bin/tiles"),
+            Path::new("/home/user/.local/share/tiles"),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn uses_elevation_only_for_unwritable_system_layout() {
+        let system_layout = UpdateInstallLayout {
+            install_dir: PathBuf::from(SYSTEM_BIN_DIR),
+            lib_dir: PathBuf::from(SYSTEM_LIB_DIR),
+            is_system: true,
+        };
+        assert!(!update_needs_elevation(&system_layout, |_| true).unwrap());
+        assert!(update_needs_elevation(&system_layout, |_| false).unwrap());
+
+        for layout in [
+            UpdateInstallLayout {
+                install_dir: PathBuf::from("/home/user/.local/bin"),
+                lib_dir: PathBuf::from("/home/user/.local/share/tiles"),
+                is_system: false,
+            },
+            UpdateInstallLayout {
+                install_dir: PathBuf::from("/opt/portable-tiles"),
+                lib_dir: PathBuf::from("/opt/portable-tiles"),
+                is_system: false,
+            },
+        ] {
+            let error = update_needs_elevation(&layout, |_| false).unwrap_err();
+            assert!(error.to_string().contains("will not use sudo"));
+        }
+    }
+
+    #[test]
+    fn checks_nearest_existing_ancestor_for_new_destinations() {
+        let root = tempdir().unwrap();
+        let destination = root.path().join("missing/nested/directory");
+
+        assert_eq!(nearest_existing_ancestor(&destination), Some(root.path()));
+        assert!(destination_is_writable(&destination));
+    }
+
     #[tokio::test]
     async fn test_get_latest_version() {
         let mock_server = MockServer::start().await;


### PR DESCRIPTION
- Preserve system, user-local, and portable installation paths during updates
- Avoids installing conflicting versions at the same times on `tiles update`
- Reject updating unwritable user and portable installations to avoid creating root-owned files