### PR TITLE
feat: show atmosphere account and keep awake in the menu bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7997,6 +7997,7 @@ dependencies = [
 name = "tiles-menubar"
 version = "0.1.0"
 dependencies = [
+ "data-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/apps/menubar/src-tauri/Cargo.toml
+++ b/apps/menubar/src-tauri/Cargo.toml
@@ -14,8 +14,11 @@ tauri = { version = "2.11", features = [] }
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "c9ec2130422200f0863b23dfdad02b133a529b07" }
 tauri-plugin-single-instance = "2"
 
-# the daemon is plain http on loopback, a TLS backend would be dead weight
-reqwest = { version = "0.12", default-features = false }
+# loopback for the daemon and https for the pds, and default-tls is the system
+# store on macos rather than a second one bundled in
+reqwest = { version = "0.12", default-features = false, features = ["default-tls"] }
+# base64 for the avatar
+data-encoding = "2"
 tokio = { version = "1", features = ["time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/menubar/src-tauri/src/atproto.rs
+++ b/apps/menubar/src-tauri/src/atproto.rs
@@ -1,0 +1,222 @@
+//! the atproto session, held by the daemon and signed in from the cli
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::daemon;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+pub const STATE_EVENT: &str = "atproto://state";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum State {
+    /// no daemon to ask through
+    Unknown,
+    /// the daemon answered, nobody is signed in
+    None,
+    /// asked for, and the browser has not come back yet
+    Pending {
+        handle: String,
+    },
+    Session {
+        handle: String,
+        did: String,
+    },
+}
+
+struct Atproto {
+    state: Mutex<State>,
+    /// the daemon binds 8988 for the callback, so a second login cannot start
+    in_flight: AtomicBool,
+}
+
+pub fn init(app: &AppHandle) {
+    app.manage(Atproto {
+        state: Mutex::new(State::Unknown),
+        in_flight: AtomicBool::new(false),
+    });
+}
+
+fn current(app: &AppHandle) -> State {
+    app.state::<Atproto>().state.lock().unwrap().clone()
+}
+
+/// emits on change only, same as the daemon's health
+fn set(app: &AppHandle, next: State) {
+    let atproto = app.state::<Atproto>();
+    let mut state = atproto.state.lock().unwrap();
+    if *state == next {
+        return;
+    }
+    *state = next.clone();
+    drop(state);
+
+    let _ = app.emit(STATE_EVENT, next);
+}
+
+/// the daemon stopped answering, and it is the only way in
+pub fn unknown(app: &AppHandle) {
+    set(app, State::Unknown);
+}
+
+/// one supervisor tick, only while the daemon answers
+pub async fn poll(app: &AppHandle, client: &reqwest::Client) {
+    // a login owns the state until the browser comes back, and the daemon
+    // reports signed out for the whole of that
+    if app.state::<Atproto>().in_flight.load(Ordering::SeqCst) {
+        return;
+    }
+
+    // unlike the local did this goes both ways, `tiles accounts at login` and
+    // `logout` flip it under us, so there is nothing to cache
+    set(app, fetch(client).await);
+}
+
+async fn fetch(client: &reqwest::Client) -> State {
+    let Ok(res) = client
+        .get(daemon::url("/v1/tilekit/atproto/status"))
+        .send()
+        .await
+    else {
+        return State::Unknown;
+    };
+
+    // 404 is the answer for nobody signed in, every other failure is the daemon
+    // saying nothing, which is not the same as saying there is no session
+    if res.status() == reqwest::StatusCode::NOT_FOUND {
+        return State::None;
+    }
+    if !res.status().is_success() {
+        return State::Unknown;
+    }
+
+    match res.text().await {
+        Ok(body) => parse(&body),
+        Err(_) => State::Unknown,
+    }
+}
+
+/// the success body only, a non-2xx never reaches here
+fn parse(body: &str) -> State {
+    // reqwest is built without its json feature, serde_json is already here
+    let Ok(payload) = serde_json::from_str::<serde_json::Value>(body) else {
+        return State::Unknown;
+    };
+
+    let data = payload.get("data");
+    let handle = data.and_then(|d| d.get("handle")).and_then(|v| v.as_str());
+    let did = data.and_then(|d| d.get("did")).and_then(|v| v.as_str());
+
+    match (handle, did) {
+        (Some(handle), Some(did)) if !handle.is_empty() && !did.is_empty() => State::Session {
+            handle: handle.to_owned(),
+            did: did.to_owned(),
+        },
+        // a success carrying neither is the daemon contradicting itself, and a
+        // signed-out claim is the one thing it should not be read as
+        _ => State::Unknown,
+    }
+}
+
+#[tauri::command]
+pub fn atproto_state(app: AppHandle) -> State {
+    current(&app)
+}
+
+/// the daemon resolves the handle, opens the browser itself and holds the
+/// request until the redirect lands, so this waits with no upper bound
+#[tauri::command]
+pub async fn atproto_login(app: AppHandle, handle: String) -> Result<(), String> {
+    let handle = handle.trim().trim_start_matches('@').to_lowercase();
+    if handle.is_empty() {
+        return Err("A handle is needed".into());
+    }
+
+    if app
+        .state::<Atproto>()
+        .in_flight
+        .swap(true, Ordering::SeqCst)
+    {
+        return Err("A sign-in is already waiting".into());
+    }
+
+    set(
+        &app,
+        State::Pending {
+            handle: handle.clone(),
+        },
+    );
+
+    let outcome = request(&handle).await;
+    app.state::<Atproto>()
+        .in_flight
+        .store(false, Ordering::SeqCst);
+
+    if let Err(err) = outcome {
+        // the next tick reports whatever the daemon actually holds
+        set(&app, State::Unknown);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+async fn request(handle: &str) -> Result<(), String> {
+    // no timeout on this one, the wait is however long the browser takes
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({ "user_handle": handle }).to_string();
+
+    let res = client
+        .post(daemon::url("/v1/tilekit/atproto/login"))
+        .header("content-type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let status = res.status();
+    if status.is_success() {
+        return Ok(());
+    }
+
+    Err(reason(&res.text().await.unwrap_or_default(), status))
+}
+
+/// the daemon says why in the body, and its reasons are the readable half of
+/// what went wrong
+fn reason(body: &str, status: reqwest::StatusCode) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .as_ref()
+        .and_then(|payload| payload.get("reason"))
+        .and_then(|v| v.as_str())
+        .map(|reason| reason.to_owned())
+        .unwrap_or_else(|| format!("The daemon answered {status}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{State, parse};
+
+    /// the shape `status` builds, tiles/src/daemon/atproto.rs
+    const SUCCESS: &str = r#"{"status":"success","data":{"handle":"codelif.in","did":"did:plc:7iza6de2dwap2sbkpav7c6c6"}}"#;
+
+    #[test]
+    fn reads_the_daemons_success_body() {
+        assert_eq!(
+            parse(SUCCESS),
+            State::Session {
+                handle: "codelif.in".to_owned(),
+                did: "did:plc:7iza6de2dwap2sbkpav7c6c6".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_body_without_an_identity_is_not_a_sign_out() {
+        assert_eq!(parse(r#"{"status":"success","data":{}}"#), State::Unknown);
+        assert_eq!(parse("not json"), State::Unknown);
+    }
+}

--- a/apps/menubar/src-tauri/src/atproto.rs
+++ b/apps/menubar/src-tauri/src/atproto.rs
@@ -2,12 +2,23 @@
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use crate::daemon;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
 
 pub const STATE_EVENT: &str = "atproto://state";
+
+/// the pds serves the blob at whatever size it was uploaded, and 22px of it is
+/// all this draws
+const AVATAR_MAX_BYTES: u64 = 2 * 1024 * 1024;
+
+/// what an <img> renders, so a record pointing anywhere else is never fetched
+const AVATAR_TYPES: [&str; 4] = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+/// the pds is not the daemon, this round trip leaves the machine
+const PROFILE_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "state", rename_all = "lowercase")]
@@ -17,25 +28,48 @@ pub enum State {
     /// the daemon answered, nobody is signed in
     None,
     /// asked for, and the browser has not come back yet
-    Pending {
-        handle: String,
-    },
+    Pending { handle: String },
     Session {
         handle: String,
         did: String,
+        /// the container renames variants and not fields, so this says it
+        #[serde(rename = "displayName")]
+        display_name: Option<String>,
+        /// a data uri, ready for an <img src>
+        avatar: Option<String>,
+        /// the host holding the repo, which the detail view names
+        pds: Option<String>,
     },
+}
+
+/// the public half of the profile record, read off the pds and not the daemon
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct Profile {
+    display_name: Option<String>,
+    avatar: Option<String>,
+    pds: Option<String>,
+}
+
+#[derive(Default)]
+struct Profiles {
+    /// settled reads, keyed by the did they belong to
+    loaded: Option<(String, Profile)>,
+    /// the did a task already has out, so a tick does not start a second
+    reading: Option<String>,
 }
 
 struct Atproto {
     state: Mutex<State>,
     /// the daemon binds 8988 for the callback, so a second login cannot start
     in_flight: AtomicBool,
+    profiles: Mutex<Profiles>,
 }
 
 pub fn init(app: &AppHandle) {
     app.manage(Atproto {
         state: Mutex::new(State::Unknown),
         in_flight: AtomicBool::new(false),
+        profiles: Mutex::new(Profiles::default()),
     });
 }
 
@@ -71,7 +105,8 @@ pub async fn poll(app: &AppHandle, client: &reqwest::Client) {
 
     // unlike the local did this goes both ways, `tiles accounts at login` and
     // `logout` flip it under us, so there is nothing to cache
-    set(app, fetch(client).await);
+    let next = dress(app, fetch(client).await);
+    set(app, next);
 }
 
 async fn fetch(client: &reqwest::Client) -> State {
@@ -113,11 +148,264 @@ fn parse(body: &str) -> State {
         (Some(handle), Some(did)) if !handle.is_empty() && !did.is_empty() => State::Session {
             handle: handle.to_owned(),
             did: did.to_owned(),
+            display_name: None,
+            avatar: None,
+            pds: None,
         },
         // a success carrying neither is the daemon contradicting itself, and a
         // signed-out claim is the one thing it should not be read as
         _ => State::Unknown,
     }
+}
+
+/// the status route carries the identity only, so the profile behind it is this
+/// app's own read and lands a tick or two later
+fn dress(app: &AppHandle, state: State) -> State {
+    let State::Session { handle, did, .. } = state else {
+        return state;
+    };
+
+    let profile = {
+        let atproto = app.state::<Atproto>();
+        let mut profiles = atproto.profiles.lock().unwrap();
+        match &profiles.loaded {
+            Some((seen, profile)) if *seen == did => profile.clone(),
+            _ => {
+                if profiles.reading.as_deref() != Some(did.as_str()) {
+                    profiles.reading = Some(did.clone());
+                    spawn_read(app.clone(), did.clone());
+                }
+                Profile::default()
+            }
+        }
+    };
+
+    State::Session {
+        handle,
+        did,
+        display_name: profile.display_name,
+        avatar: profile.avatar,
+        pds: profile.pds,
+    }
+}
+
+/// off the watch loop, whose client times out in a second and whose other polls
+/// are waiting behind it
+fn spawn_read(app: AppHandle, did: String) {
+    tauri::async_runtime::spawn(async move {
+        let profile = read_profile(&did).await;
+
+        {
+            let atproto = app.state::<Atproto>();
+            let mut profiles = atproto.profiles.lock().unwrap();
+            profiles.reading = None;
+            // a pds that said nothing caches nothing, so the next tick asks again
+            if let Some(profile) = profile.clone() {
+                profiles.loaded = Some((did.clone(), profile));
+            }
+        }
+
+        let Some(profile) = profile else {
+            return;
+        };
+
+        // the identity can move while this is out, and the picture belongs to
+        // the one that was asked for
+        let State::Session {
+            handle, did: at, ..
+        } = current(&app)
+        else {
+            return;
+        };
+        if at != did {
+            return;
+        }
+
+        set(
+            &app,
+            State::Session {
+                handle,
+                did: at,
+                display_name: profile.display_name,
+                avatar: profile.avatar,
+                pds: profile.pds,
+            },
+        );
+    });
+}
+
+/// `None` is the pds saying nothing, which is not the same as an account that
+/// has set no picture
+async fn read_profile(did: &str) -> Option<Profile> {
+    let client = reqwest::Client::builder()
+        .timeout(PROFILE_TIMEOUT)
+        .build()
+        .ok()?;
+
+    let pds = resolve_pds(&client, did).await?;
+    let res = client
+        .get(format!(
+            "{pds}/xrpc/com.atproto.repo.getRecord?repo={did}&collection=app.bsky.actor.profile&rkey=self"
+        ))
+        .send()
+        .await
+        .ok()?;
+
+    // an account that never wrote the record answers 400 and not 404, so any
+    // refusal here is an empty profile rather than a pds that went quiet
+    if !res.status().is_success() {
+        return Some(Profile {
+            pds: Some(pds),
+            ..Profile::default()
+        });
+    }
+
+    let (display_name, blob) = parse_profile(&res.text().await.ok()?);
+    let avatar = match blob {
+        Some((cid, mime)) => blob_uri(&client, &pds, did, &cid, &mime).await,
+        None => None,
+    };
+
+    Some(Profile {
+        display_name,
+        avatar,
+        pds: Some(pds),
+    })
+}
+
+/// the did document says which pds holds the repo, and the daemon is not in
+/// this path to have resolved it already
+async fn resolve_pds(client: &reqwest::Client, did: &str) -> Option<String> {
+    let res = client.get(did_doc_url(did)?).send().await.ok()?;
+    if !res.status().is_success() {
+        return None;
+    }
+
+    pds_from_doc(&res.text().await.ok()?)
+}
+
+/// plc keeps its documents in one directory, did:web serves its own
+fn did_doc_url(did: &str) -> Option<String> {
+    if !is_token(did) {
+        return None;
+    }
+
+    if did.starts_with("did:plc:") {
+        return Some(format!("https://plc.directory/{did}"));
+    }
+
+    // the host form only, the path form maps colons to slashes and a guess at
+    // one is worse than drawing initials
+    let host = did.strip_prefix("did:web:")?;
+    if host.is_empty() || host.contains(':') {
+        return None;
+    }
+
+    Some(format!("https://{host}/.well-known/did.json"))
+}
+
+/// these get joined into urls, and the daemon is not the only thing that could
+/// have put them there
+fn is_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b':' | b'.' | b'_' | b'-'))
+}
+
+/// the endpoint of the service entry that holds the repo
+fn pds_from_doc(body: &str) -> Option<String> {
+    let doc = serde_json::from_str::<serde_json::Value>(body).ok()?;
+    let endpoint = doc
+        .get("service")?
+        .as_array()?
+        .iter()
+        .find(|entry| {
+            entry.get("type").and_then(|v| v.as_str()) == Some("AtprotoPersonalDataServer")
+        })?
+        .get("serviceEndpoint")?
+        .as_str()?;
+
+    // everything after this is built by joining onto it, and only https is
+    // worth sending a did to
+    if !endpoint.starts_with("https://") {
+        return None;
+    }
+
+    Some(endpoint.trim_end_matches('/').to_owned())
+}
+
+/// the record body, whose avatar is a blob ref and not a url
+fn parse_profile(body: &str) -> (Option<String>, Option<(String, String)>) {
+    let Ok(payload) = serde_json::from_str::<serde_json::Value>(body) else {
+        return (None, None);
+    };
+
+    let value = payload.get("value");
+    let display_name = value
+        .and_then(|v| v.get("displayName"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned);
+
+    let avatar = value.and_then(|v| v.get("avatar"));
+    let cid = avatar
+        .and_then(|a| a.get("ref"))
+        .and_then(|r| r.get("$link"))
+        .and_then(|v| v.as_str());
+    let mime = avatar
+        .and_then(|a| a.get("mimeType"))
+        .and_then(|v| v.as_str());
+
+    let blob = match (cid, mime) {
+        (Some(cid), Some(mime)) if AVATAR_TYPES.contains(&mime) && is_token(cid) => {
+            Some((cid.to_owned(), mime.to_owned()))
+        }
+        _ => None,
+    };
+
+    (display_name, blob)
+}
+
+async fn blob_uri(
+    client: &reqwest::Client,
+    pds: &str,
+    did: &str,
+    cid: &str,
+    mime: &str,
+) -> Option<String> {
+    let res = client
+        .get(format!(
+            "{pds}/xrpc/com.atproto.sync.getBlob?did={did}&cid={cid}"
+        ))
+        .send()
+        .await
+        .ok()?;
+
+    if !res.status().is_success() {
+        return None;
+    }
+
+    // the header is advisory, so it only saves reading a body that already
+    // admits it is too big
+    if res
+        .content_length()
+        .is_some_and(|len| len > AVATAR_MAX_BYTES)
+    {
+        return None;
+    }
+
+    let bytes = res.bytes().await.ok()?;
+    if bytes.len() as u64 > AVATAR_MAX_BYTES {
+        return None;
+    }
+
+    Some(format!(
+        "data:{mime};base64,{}",
+        data_encoding::BASE64.encode(&bytes)
+    ))
 }
 
 #[tauri::command]
@@ -198,10 +486,13 @@ fn reason(body: &str, status: reqwest::StatusCode) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{State, parse};
+    use super::{State, did_doc_url, parse, parse_profile, pds_from_doc};
 
     /// the shape `status` builds, tiles/src/daemon/atproto.rs
     const SUCCESS: &str = r#"{"status":"success","data":{"handle":"codelif.in","did":"did:plc:7iza6de2dwap2sbkpav7c6c6"}}"#;
+
+    /// the shape a pds returns for app.bsky.actor.profile/self
+    const RECORD: &str = r#"{"uri":"at://did:plc:x/app.bsky.actor.profile/self","value":{"$type":"app.bsky.actor.profile","displayName":"Harsh Sharma","avatar":{"$type":"blob","ref":{"$link":"bafkreiabc123"},"mimeType":"image/jpeg","size":91234}}}"#;
 
     #[test]
     fn reads_the_daemons_success_body() {
@@ -210,6 +501,9 @@ mod tests {
             State::Session {
                 handle: "codelif.in".to_owned(),
                 did: "did:plc:7iza6de2dwap2sbkpav7c6c6".to_owned(),
+                display_name: None,
+                avatar: None,
+                pds: None,
             }
         );
     }
@@ -218,5 +512,56 @@ mod tests {
     fn a_body_without_an_identity_is_not_a_sign_out() {
         assert_eq!(parse(r#"{"status":"success","data":{}}"#), State::Unknown);
         assert_eq!(parse("not json"), State::Unknown);
+    }
+
+    #[test]
+    fn finds_the_pds_in_a_did_document() {
+        // the id carries a fragment, hence the wider raw string
+        let doc = r##"{"service":[{"id":"#atproto_pds","type":"AtprotoPersonalDataServer","serviceEndpoint":"https://shimeji.us-east.host.bsky.network/"}]}"##;
+        assert_eq!(
+            pds_from_doc(doc).as_deref(),
+            Some("https://shimeji.us-east.host.bsky.network")
+        );
+
+        // a document with no pds entry, and one served over plain http
+        assert_eq!(pds_from_doc(r#"{"service":[]}"#), None);
+        let plain = r#"{"service":[{"type":"AtprotoPersonalDataServer","serviceEndpoint":"http://pds.example"}]}"#;
+        assert_eq!(pds_from_doc(plain), None);
+    }
+
+    #[test]
+    fn reads_the_profile_record() {
+        let (name, blob) = parse_profile(RECORD);
+        assert_eq!(name.as_deref(), Some("Harsh Sharma"));
+        assert_eq!(
+            blob,
+            Some(("bafkreiabc123".to_owned(), "image/jpeg".to_owned()))
+        );
+    }
+
+    #[test]
+    fn a_record_without_a_picture_is_not_a_failure() {
+        let (name, blob) = parse_profile(r#"{"value":{"displayName":"Harsh"}}"#);
+        assert_eq!(name.as_deref(), Some("Harsh"));
+        assert_eq!(blob, None);
+
+        // a blob that an <img> would not render is left alone
+        let odd = r#"{"value":{"avatar":{"ref":{"$link":"bafkrei1"},"mimeType":"video/mp4"}}}"#;
+        assert_eq!(parse_profile(odd), (None, None));
+    }
+
+    #[test]
+    fn only_resolvable_dids_become_urls() {
+        assert_eq!(
+            did_doc_url("did:plc:abc").as_deref(),
+            Some("https://plc.directory/did:plc:abc")
+        );
+        assert_eq!(
+            did_doc_url("did:web:example.com").as_deref(),
+            Some("https://example.com/.well-known/did.json")
+        );
+        // the path form, and a did carrying url of its own
+        assert_eq!(did_doc_url("did:web:example.com:u:alice"), None);
+        assert_eq!(did_doc_url("did:plc:a/../../evil"), None);
     }
 }

--- a/apps/menubar/src-tauri/src/awake.rs
+++ b/apps/menubar/src-tauri/src/awake.rs
@@ -1,0 +1,417 @@
+//! holding the mac up, for as long as there is something worth staying up for
+
+use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+pub const STATE_EVENT: &str = "awake://state";
+
+/// the tool holds the assertion, and `-w` releases it even on a kill we never
+/// see coming, which a Drop impl cannot promise
+const CAFFEINATE: &str = "/usr/bin/caffeinate";
+
+/// -2.0, an external source with no battery to run down. a desktop reads this
+/// too, which is the right answer for a machine that is always plugged in
+const UNLIMITED: f64 = -2.0;
+
+#[link(name = "IOKit", kind = "framework")]
+unsafe extern "C" {
+    fn IOPSGetTimeRemainingEstimate() -> f64;
+}
+
+fn on_ac() -> bool {
+    unsafe { IOPSGetTimeRemainingEstimate() == UNLIMITED }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct State {
+    /// the assertion is held right now
+    pub active: bool,
+    /// a session exists but is held, its clock stopped and its assertion down
+    pub paused: bool,
+    /// unix ms an open ended session counts up from, while it is running
+    pub since: Option<u64>,
+    /// unix ms a timed session counts down to, while it is running
+    pub until: Option<u64>,
+    /// the reading in ms while paused, which has no wall clock to sit against.
+    /// already whole seconds, so it does not step when the clock stops
+    pub frozen: Option<u64>,
+    /// on battery none of it can be taken at all, and the plate says so
+    pub ac: bool,
+}
+
+const IDLE: State = State {
+    active: false,
+    paused: false,
+    since: None,
+    until: None,
+    frozen: None,
+    ac: false,
+};
+
+/// a run of the clock, which pausing banks and resuming starts again
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct Session {
+    /// total length in ms, `None` being the open ended one
+    length: Option<u64>,
+    /// ms banked by earlier runs, which is the whole clock while paused
+    elapsed: u64,
+    /// unix ms the run in progress began, `None` while paused
+    started: Option<u64>,
+}
+
+impl Session {
+    fn running(&self) -> bool {
+        self.started.is_some()
+    }
+
+    /// ms on the clock, counting the run in progress
+    fn ran(&self, now: u64) -> u64 {
+        self.elapsed + self.started.map_or(0, |at| now.saturating_sub(at))
+    }
+
+    /// ms before it ends, `None` for the open ended one
+    fn left(&self, now: u64) -> Option<u64> {
+        self.length.map(|len| len.saturating_sub(self.ran(now)))
+    }
+
+    fn expired(&self, now: u64) -> bool {
+        self.length.is_some_and(|len| self.ran(now) >= len)
+    }
+
+    /// the wall clock an open ended run counts up from. `started - elapsed`
+    /// rather than anything involving now, so a tick that changed nothing does
+    /// not look to the panel like a change
+    fn since(&self) -> Option<u64> {
+        if self.length.is_some() {
+            return None;
+        }
+        Some(self.started?.saturating_sub(self.elapsed))
+    }
+
+    /// the wall clock a timed run counts down to, steady for the same reason
+    fn until(&self) -> Option<u64> {
+        Some(self.started? + self.length?.saturating_sub(self.elapsed))
+    }
+
+    /// what a stopped clock reads, rounded the way a running one is so it does
+    /// not step a second when it is paused
+    fn frozen(&self) -> u64 {
+        match self.length {
+            Some(len) => len.saturating_sub(self.elapsed).div_ceil(1000) * 1000,
+            None => self.elapsed / 1000 * 1000,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Held {
+    /// the tool, alive for exactly as long as the assertion is
+    child: Option<Child>,
+    session: Option<Session>,
+}
+
+struct Awake {
+    held: Mutex<Held>,
+    state: Mutex<State>,
+}
+
+pub fn init(app: &AppHandle) {
+    app.manage(Awake {
+        held: Mutex::new(Held::default()),
+        // the first tick corrects the mains, and off is the safe thing to draw
+        state: Mutex::new(IDLE),
+    });
+}
+
+/// emits on change only, same as the daemon's health
+fn set(app: &AppHandle, next: State) {
+    let awake = app.state::<Awake>();
+    let mut state = awake.state.lock().unwrap();
+    if *state == next {
+        return;
+    }
+    *state = next;
+    drop(state);
+
+    let _ = app.emit(STATE_EVENT, next);
+}
+
+/// what the panel draws, off the session rather than off the clock, so a tick
+/// that moved nothing emits nothing
+fn describe(held: &Held, ac: bool) -> State {
+    let Some(session) = held.session else {
+        return State { ac, ..IDLE };
+    };
+
+    if session.running() {
+        return State {
+            active: held.child.is_some(),
+            since: session.since(),
+            until: session.until(),
+            ac,
+            ..IDLE
+        };
+    }
+
+    State {
+        paused: true,
+        frozen: Some(session.frozen()),
+        ac,
+        ..IDLE
+    }
+}
+
+/// the only place the child is started or killed, so the assertion and what the
+/// panel was told can never disagree
+fn reconcile(app: &AppHandle) {
+    let ac = on_ac();
+    let now = now_ms();
+    let awake = app.state::<Awake>();
+    let mut held = awake.held.lock().unwrap();
+
+    // the tool went away on its own, which is `-t` running out or a kill from
+    // outside. the assertion went with it, so the session is over
+    if let Some(child) = held.child.as_mut()
+        && matches!(child.try_wait(), Ok(Some(_)) | Err(_))
+    {
+        held.child = None;
+        held.session = None;
+    }
+
+    // the mains going away ends the session rather than holding it, so the
+    // cable coming back does not relight the plate on its own
+    if !ac {
+        held.session = None;
+    }
+
+    if held.session.is_some_and(|session| session.expired(now)) {
+        held.session = None;
+    }
+
+    let running = held.session.is_some_and(|session| session.running());
+    match (running, held.child.is_some()) {
+        (true, false) => {
+            let mut command = Command::new(CAFFEINATE);
+            // `-i` keeps the system up and leaves the display free to sleep
+            command.arg("-i");
+            if let Some(left) = held.session.and_then(|session| session.left(now)) {
+                // the kernel holds the deadline, so it survives a sleep the way
+                // a timer of our own would not
+                command.args(["-t", &left.div_ceil(1000).max(1).to_string()]);
+            }
+            // no utility to run, so the assertion stands until the tool exits
+            command.args(["-w", &std::process::id().to_string()]);
+
+            match command
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+            {
+                Ok(child) => held.child = Some(child),
+                // nothing to report but the plate staying dark, which the state
+                // below already says
+                Err(_) => held.session = None,
+            }
+        }
+        (false, true) => {
+            if let Some(mut child) = held.child.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+        _ => {}
+    }
+
+    let next = describe(&held, ac);
+    drop(held);
+
+    set(app, next);
+}
+
+/// one supervisor pass, outside the health branch. the mains and the deadline
+/// are not the daemon's business, and a session outlives it going away
+pub fn tick(app: &AppHandle) {
+    reconcile(app);
+}
+
+#[tauri::command]
+pub fn awake_state(app: AppHandle) -> State {
+    *app.state::<Awake>().state.lock().unwrap()
+}
+
+/// `seconds` of `None` is the open ended one the menu offers last. a pick while
+/// one is already going replaces it rather than stacking on it
+#[tauri::command]
+pub fn awake_start(app: AppHandle, seconds: Option<u64>) {
+    {
+        let awake = app.state::<Awake>();
+        let mut held = awake.held.lock().unwrap();
+        held.session = Some(Session {
+            length: seconds.map(|s| s * 1000),
+            elapsed: 0,
+            started: Some(now_ms()),
+        });
+    }
+    reconcile(&app);
+}
+
+#[tauri::command]
+pub fn awake_stop(app: AppHandle) {
+    {
+        let awake = app.state::<Awake>();
+        let mut held = awake.held.lock().unwrap();
+        held.session = None;
+    }
+    reconcile(&app);
+}
+
+/// banks the run so far and drops the assertion. the clock keeps its reading
+#[tauri::command]
+pub fn awake_pause(app: AppHandle) {
+    {
+        let now = now_ms();
+        let awake = app.state::<Awake>();
+        let mut held = awake.held.lock().unwrap();
+        if let Some(session) = held.session.as_mut()
+            && let Some(at) = session.started.take()
+        {
+            session.elapsed += now.saturating_sub(at);
+        }
+    }
+    reconcile(&app);
+}
+
+#[tauri::command]
+pub fn awake_resume(app: AppHandle) {
+    {
+        let awake = app.state::<Awake>();
+        let mut held = awake.held.lock().unwrap();
+        if let Some(session) = held.session.as_mut()
+            && session.started.is_none()
+        {
+            session.started = Some(now_ms());
+        }
+    }
+    reconcile(&app);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Session;
+
+    const NOW: u64 = 1_700_000_000_000;
+
+    fn timed(minutes: u64) -> Session {
+        Session {
+            length: Some(minutes * 60_000),
+            elapsed: 0,
+            started: Some(NOW),
+        }
+    }
+
+    /// the run in progress counts, and the banked part counts with it
+    #[test]
+    fn the_clock_is_the_banked_time_plus_the_run_in_progress() {
+        let session = Session {
+            elapsed: 20_000,
+            started: Some(NOW),
+            ..timed(15)
+        };
+        assert_eq!(session.ran(NOW + 5_000), 25_000);
+        assert_eq!(session.left(NOW + 5_000), Some(15 * 60_000 - 25_000));
+    }
+
+    /// pausing banks the run, and what is left does not move while it is held
+    #[test]
+    fn a_paused_clock_does_not_move() {
+        let held = Session {
+            elapsed: 60_000,
+            started: None,
+            ..timed(15)
+        };
+        assert_eq!(held.left(NOW), held.left(NOW + 3_600_000));
+        assert!(!held.running());
+    }
+
+    /// resuming picks the run up where it was banked rather than restarting it
+    #[test]
+    fn resuming_carries_the_banked_time_over() {
+        let resumed = Session {
+            elapsed: 60_000,
+            started: Some(NOW),
+            ..timed(15)
+        };
+        assert_eq!(resumed.ran(NOW + 30_000), 90_000);
+    }
+
+    /// the anchors the panel counts against are steady, so a tick that moved
+    /// nothing is not an emit
+    #[test]
+    fn the_anchors_do_not_drift_with_the_clock() {
+        let session = Session {
+            elapsed: 60_000,
+            started: Some(NOW),
+            ..timed(15)
+        };
+        assert_eq!(session.until(), Some(NOW + 15 * 60_000 - 60_000));
+        assert_eq!(session.since(), None);
+
+        let open = Session {
+            length: None,
+            elapsed: 60_000,
+            started: Some(NOW),
+        };
+        assert_eq!(open.since(), Some(NOW - 60_000));
+        assert_eq!(open.until(), None);
+    }
+
+    #[test]
+    fn a_session_is_over_once_it_has_run_its_length() {
+        let session = timed(15);
+        assert!(!session.expired(NOW + 15 * 60_000 - 1));
+        assert!(session.expired(NOW + 15 * 60_000));
+    }
+
+    /// an open ended one has nothing to run out of
+    #[test]
+    fn an_open_ended_session_never_expires() {
+        let open = Session {
+            length: None,
+            elapsed: 0,
+            started: Some(NOW),
+        };
+        assert!(!open.expired(NOW + 86_400_000));
+        assert_eq!(open.left(NOW), None);
+    }
+
+    /// a stopped clock reads in whole seconds, the way the running one does
+    #[test]
+    fn a_frozen_reading_is_rounded_like_a_running_one() {
+        let timed_held = Session {
+            elapsed: 500,
+            started: None,
+            ..timed(1)
+        };
+        assert_eq!(timed_held.frozen(), 60_000);
+
+        let open_held = Session {
+            length: None,
+            elapsed: 1_500,
+            started: None,
+        };
+        assert_eq!(open_held.frozen(), 1_000);
+    }
+}

--- a/apps/menubar/src-tauri/src/daemon.rs
+++ b/apps/menubar/src-tauri/src/daemon.rs
@@ -3,7 +3,7 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
-use crate::{account, inference, remote, sessions};
+use crate::{account, atproto, inference, remote, sessions};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -95,6 +95,7 @@ async fn watch(app: AppHandle) {
                 set(&app, Health::Up { version });
                 inference::poll(&app, &client).await;
                 account::poll(&app, &client).await;
+                atproto::poll(&app, &client).await;
                 remote::poll(&app, &client).await;
             }
             None => {
@@ -106,6 +107,7 @@ async fn watch(app: AppHandle) {
                 );
                 inference::unknown(&app);
                 account::unknown(&app);
+                atproto::unknown(&app);
                 sessions::unknown(&app);
                 remote::unknown(&app);
             }

--- a/apps/menubar/src-tauri/src/daemon.rs
+++ b/apps/menubar/src-tauri/src/daemon.rs
@@ -3,7 +3,7 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
-use crate::{account, atproto, inference, remote, sessions};
+use crate::{account, atproto, awake, inference, remote, sessions};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -90,6 +90,10 @@ async fn watch(app: AppHandle) {
         .expect("a client with only a timeout set always builds");
 
     loop {
+        // outside the branch below: the mains are not the daemon's business,
+        // and a manual assertion outlives it going away
+        awake::tick(&app);
+
         match ping(&client).await {
             Some(version) => {
                 set(&app, Health::Up { version });

--- a/apps/menubar/src-tauri/src/main.rs
+++ b/apps/menubar/src-tauri/src/main.rs
@@ -1,4 +1,5 @@
 mod account;
+mod atproto;
 mod clipboard;
 mod daemon;
 mod inference;
@@ -33,6 +34,8 @@ fn main() {
             inference::inference_state,
             inference::inference_set,
             account::account_state,
+            atproto::atproto_state,
+            atproto::atproto_login,
             sessions::sessions_state,
             remote::remote_state,
             remote::remote_set
@@ -48,6 +51,7 @@ fn main() {
             // before the watcher, its first tick already reports all three
             inference::init(app.handle());
             account::init(app.handle());
+            atproto::init(app.handle());
             sessions::init(app.handle());
             remote::init(app.handle());
             daemon::init(app.handle());

--- a/apps/menubar/src-tauri/src/main.rs
+++ b/apps/menubar/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
 mod account;
 mod atproto;
+mod awake;
 mod clipboard;
 mod daemon;
 mod inference;
@@ -38,7 +39,12 @@ fn main() {
             atproto::atproto_login,
             sessions::sessions_state,
             remote::remote_state,
-            remote::remote_set
+            remote::remote_set,
+            awake::awake_state,
+            awake::awake_start,
+            awake::awake_stop,
+            awake::awake_pause,
+            awake::awake_resume
         ])
         .setup(|app| {
             // LSUIElement covers the launch window before this runs
@@ -54,6 +60,8 @@ fn main() {
             atproto::init(app.handle());
             sessions::init(app.handle());
             remote::init(app.handle());
+            // before the watcher, whose every pass reconciles it
+            awake::init(app.handle());
             daemon::init(app.handle());
 
             panel::warm_up(app.handle());

--- a/apps/menubar/src/Panel.svelte
+++ b/apps/menubar/src/Panel.svelte
@@ -7,6 +7,7 @@
   import { nav, type ViewId } from "./nav.svelte";
   import { connect } from "./state.svelte";
   import AccountView from "./views/AccountView.svelte";
+  import AtmosphereView from "./views/AtmosphereView.svelte";
   import ModelView from "./views/ModelView.svelte";
   import RootView from "./views/RootView.svelte";
   import SessionsView from "./views/SessionsView.svelte";
@@ -87,6 +88,8 @@
     {#snippet view(id: ViewId)}
       {#if id === "account"}
         <AccountView />
+      {:else if id === "atmosphere"}
+        <AtmosphereView />
       {:else if id === "sessions"}
         <SessionsView />
       {:else if id === "model"}

--- a/apps/menubar/src/lib/Avatar.svelte
+++ b/apps/menubar/src/lib/Avatar.svelte
@@ -2,9 +2,11 @@
   interface Props {
     nickname: string;
     size?: number;
+    /** a data uri read off the pds, initials when it is absent or will not decode */
+    src?: string | null;
   }
 
-  let { nickname, size = 22 }: Props = $props();
+  let { nickname, size = 22, src = null }: Props = $props();
 
   const initials = $derived(
     nickname
@@ -14,26 +16,82 @@
       .map((part) => part[0].toUpperCase())
       .join("") || "?",
   );
+
+  let failed = $state(false);
+  let ready = $state(false);
+
+  // a new picture gets its own chance to load, and its own chance to fail
+  $effect(() => {
+    src;
+    failed = false;
+    ready = false;
+  });
+
+  const showing = $derived(!!src && !failed);
 </script>
 
-<!-- square and cut, so it sits in the same family as the provider marks -->
-<div class="avatar" style="--size: {size}px; --fs: {Math.round(size * 0.4)}px">
-  {initials}
+<!-- the switch's construction, a frame with the mark seated a pixel inside, so
+     a picture reads as machined into the row rather than laid over it -->
+<div
+  class="avatar"
+  data-framed={showing}
+  style="--size: {size}px; --fs: {Math.round(size * 0.4)}px"
+>
+  <span class="avatar__cell">
+    <!-- initials sit under the picture, so the cell is never empty mid-load -->
+    {initials}
+    {#if showing}
+      <img
+        class="avatar__img"
+        {src}
+        alt=""
+        data-ready={ready}
+        onload={() => (ready = true)}
+        onerror={() => (failed = true)}
+      />
+    {/if}
+  </span>
 </div>
 
 <style>
   .avatar {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    /* no frame by default, initials are already type on steel */
+    --frame-w: 0px;
+
     flex: none;
     width: var(--size);
     height: var(--size);
+    padding: var(--frame-w);
     clip-path: polygon(
       0 0,
       100% 0,
       100% calc(100% - var(--cut)),
       calc(100% - var(--cut)) 100%,
+      0 100%
+    );
+    transition: background var(--dur-state) ease-out;
+  }
+
+  /* a photograph needs seating, and the row hands down what colour to seat it in */
+  .avatar[data-framed="true"] {
+    --frame-w: 2px;
+
+    background: var(--mark-frame, rgba(255, 255, 255, 0.22));
+  }
+
+  /* the cut is shortened by the inset so it stays parallel to the frame's */
+  .avatar__cell {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% calc(100% - var(--cut) + var(--frame-w)),
+      calc(100% - var(--cut) + var(--frame-w)) 100%,
       0 100%
     );
     background: var(--steel);
@@ -43,5 +101,19 @@
     font-weight: 500;
     letter-spacing: 0.02em;
     transition: color var(--dur-state) ease-out;
+  }
+
+  .avatar__img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity var(--dur-state) ease-out;
+  }
+
+  .avatar__img[data-ready="true"] {
+    opacity: 1;
   }
 </style>

--- a/apps/menubar/src/lib/AwakeMenu.svelte
+++ b/apps/menubar/src/lib/AwakeMenu.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  interface Props {
+    /** a session exists, running or held */
+    session: "none" | "running" | "paused";
+    /** `null` is the open ended one */
+    onpick: (seconds: number | null) => void;
+    onpause: () => void;
+    onresume: () => void;
+    onstop: () => void;
+  }
+
+  let { session, onpick, onpause, onresume, onstop }: Props = $props();
+
+  const DURATIONS: { label: string; seconds: number | null }[] = [
+    { label: "15 minutes", seconds: 15 * 60 },
+    { label: "30 minutes", seconds: 30 * 60 },
+    { label: "1 hour", seconds: 60 * 60 },
+    { label: "2 hours", seconds: 2 * 60 * 60 },
+    { label: "4 hours", seconds: 4 * 60 * 60 },
+    { label: "Indefinitely", seconds: null },
+  ];
+</script>
+
+<div class="menu" role="menu">
+  {#if session !== "none"}
+    <!-- what to do with the session already going, above the lengths that
+         would replace it -->
+    {#if session === "running"}
+      <button class="menu__item menu__item--lead" role="menuitem" onclick={onpause}>
+        Pause
+      </button>
+    {:else}
+      <button class="menu__item menu__item--lead" role="menuitem" onclick={onresume}>
+        Resume
+      </button>
+    {/if}
+    <button class="menu__item menu__item--lead" role="menuitem" onclick={onstop}>
+      Turn off
+    </button>
+    <div class="menu__rule"></div>
+  {/if}
+
+  {#each DURATIONS as duration (duration.label)}
+    <button class="menu__item" role="menuitem" onclick={() => onpick(duration.seconds)}>
+      {duration.label}
+    </button>
+  {/each}
+</div>
+
+<style>
+  /* opens upward, the footer is the last thing in the panel. anchored on the
+     plate's right edge so it does not hang over Quit */
+  .menu {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 6px);
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    /* the plate is the anchor, so the list is at least as wide as it */
+    min-width: 100%;
+    padding: 3px 0;
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% calc(100% - var(--cut)),
+      calc(100% - var(--cut)) 100%,
+      0 100%
+    );
+    background: var(--steel);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.55);
+  }
+
+  .menu__item {
+    flex: none;
+    border: none;
+    background: transparent;
+    padding: 5px var(--pad-x);
+    color: var(--ash);
+    font-family: var(--font-ui);
+    font-size: var(--fs-body);
+    line-height: 1;
+    text-align: left;
+    white-space: nowrap;
+    transition: color var(--dur-state) ease-out;
+  }
+
+  /* acting on the running session is the reason the menu was opened */
+  .menu__item--lead {
+    color: var(--bone);
+  }
+
+  .menu__item:hover {
+    color: var(--signal);
+  }
+
+  .menu__rule {
+    margin: 3px 0;
+    height: var(--hairline);
+    background: var(--rule);
+  }
+</style>

--- a/apps/menubar/src/lib/CupMark.svelte
+++ b/apps/menubar/src/lib/CupMark.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  interface Props {
+    /** the assertion is held, and the cup is steaming */
+    active: boolean;
+  }
+
+  let { active }: Props = $props();
+</script>
+
+<!-- sized against the label beside it, not the plate, which sets its own height -->
+<svg
+  class="cup"
+  viewBox="0 0 12 12"
+  width="15"
+  height="15"
+  aria-hidden="true"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1"
+>
+  <!-- the cup owns the box and sits centred in it, so the steam overhangs the
+       rim rather than a third of the height being held back for it -->
+  <path d="M1.8 3h6.4l-.9 6h-4.6z" />
+  <!-- close to a half circle, or the opening closes up at this size and the
+       handle reads as a blob on the side -->
+  <path d="M8.1 4.4h.9a1.4 1.4 0 0 1 0 2.8h-1" />
+  {#if active}
+    <!-- butt caps, square ones overhang half a stroke and the box clips them -->
+    <path d="M4.3 .5v1.6" />
+    <path d="M6.6 .3v1.8" />
+  {/if}
+</svg>
+
+<style>
+  /* block, or the inline baseline adds a descender the plate has to pad for */
+  .cup {
+    display: block;
+    color: inherit;
+  }
+</style>

--- a/apps/menubar/src/lib/Footer.svelte
+++ b/apps/menubar/src/lib/Footer.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
 
+  import AwakeMenu from "./AwakeMenu.svelte";
+  import CupMark from "./CupMark.svelte";
+  import { awake } from "../state.svelte";
+
   interface Props {
     /** the daemon's version, or why there is no version to show */
     note: string;
@@ -9,10 +13,122 @@
   }
 
   let { note, alert = false }: Props = $props();
+
+  let menu = $state(false);
+
+  // the state event fires on change only, so the count is this side's to keep
+  let now = $state(Date.now());
+
+  $effect(() => {
+    if (!awake.value.active || awake.value.paused) return;
+    now = Date.now();
+    const timer = setInterval(() => (now = Date.now()), 1000);
+    return () => clearInterval(timer);
+  });
+
+  function clock(total: number): string {
+    const pad = (value: number) => String(value).padStart(2, "0");
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+
+    // h:mm:ss past the hour, or 4 hours and 4 minutes both read as 4:00
+    return hours > 0
+      ? `${hours}:${pad(minutes)}:${pad(total % 60)}`
+      : `${pad(minutes)}:${pad(total % 60)}`;
+  }
+
+  const session = $derived.by<"none" | "running" | "paused">(() =>
+    awake.value.paused ? "paused" : awake.value.active ? "running" : "none",
+  );
+
+  // a session with an end counts down to it, one without counts up from where
+  // it started, and a held one reads whatever it was banked at
+  const reading = $derived.by(() => {
+    const { paused, since, until, frozen } = awake.value;
+    if (paused) return frozen === null ? "" : clock(Math.round(frozen / 1000));
+    // ceil, so a fresh 15 minute session reads 15:00 rather than 14:59
+    if (until !== null) return clock(Math.ceil(Math.max(0, until - now) / 1000));
+    // floor, so a stopwatch starts at 00:00 rather than 00:01
+    if (since !== null) return clock(Math.floor(Math.max(0, now - since) / 1000));
+    return "";
+  });
+
+  function pick(seconds: number | null) {
+    menu = false;
+    void invoke("awake_start", { seconds }).catch(() => {});
+  }
+
+  function run(command: string) {
+    menu = false;
+    void invoke(command).catch(() => {});
+  }
+
+  // capture, or the panel's own handler pops the view out from under the menu
+  function onkeydowncapture(event: KeyboardEvent) {
+    if (!menu || event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    menu = false;
+  }
 </script>
+
+<svelte:window {onkeydowncapture} />
 
 <footer class="footer">
   <span class="footer__note" data-alert={alert}>{note}</span>
+
+  <div class="footer__cupwrap">
+    {#if menu}
+      <!-- the click that dismisses should not also land on whatever is under
+           it, so it is caught here rather than on the window -->
+      <button
+        class="footer__scrim"
+        tabindex="-1"
+        aria-label="Close"
+        onclick={() => (menu = false)}
+      ></button>
+      <AwakeMenu
+        {session}
+        onpick={pick}
+        onpause={() => run("awake_pause")}
+        onresume={() => run("awake_resume")}
+        onstop={() => run("awake_stop")}
+      />
+    {/if}
+
+    <button
+      class="footer__cup"
+      data-state={session}
+      disabled={!awake.value.ac}
+      aria-label="Keep this Mac awake"
+      aria-haspopup="menu"
+      aria-expanded={menu}
+      title={awake.value.ac ? "Keep this Mac awake" : "Keeping awake needs mains power"}
+      onclick={() => (menu = !menu)}
+    >
+      <!-- steam is the run, so a held session has none -->
+      <CupMark active={session === "running"} />
+      <!-- a session says where its clock is, and only a plate with none has to
+           explain what it is for -->
+      {#if session !== "none"}
+        <span class="footer__count">{reading}</span>
+      {:else}
+        <span>Keep awake</span>
+      {/if}
+
+      <!-- every click opens the menu, in every state, so the plate says so -->
+      <svg class="footer__trail" viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
+        <path
+          d="M2 6.5 5 3.5 8 6.5"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="square"
+        />
+      </svg>
+    </button>
+  </div>
+
   <button class="footer__quit" onclick={() => void invoke("quit_app").catch(() => {})}>
     Quit
   </button>
@@ -20,6 +136,9 @@
 
 <style>
   .footer {
+    /* both plates sit on this, and the icon and the word centre inside it */
+    --h-plate: 22px;
+
     position: relative;
     display: flex;
     align-items: center;
@@ -47,7 +166,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     font-family: var(--font-mono);
-    font-size: var(--fs-mono);
+    font-size: var(--fs-body);
     font-variant-numeric: tabular-nums;
     color: var(--slate);
   }
@@ -56,8 +175,44 @@
     color: var(--alert);
   }
 
+  /* full strength, a solid this small goes muddy the moment it is faded and
+     the plate's own hover is already carrying the state */
+  .footer__trail {
+    flex: none;
+    display: block;
+  }
+
+  /* a reading and not a word, so it is set like the version is. tabular, or
+     the plate breathes under it every second */
+  .footer__count {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* the menu hangs off this rather than the footer, so it lines up on the cup */
+  .footer__cupwrap {
+    position: relative;
+    flex: none;
+    display: flex;
+  }
+
+  .footer__scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    border: none;
+    background: transparent;
+  }
+
+  /* a set height rather than padding, so a plate holding an icon and a plate
+     holding a word still come out the same size */
+  .footer__cup,
   .footer__quit {
     flex: none;
+    display: flex;
+    align-items: center;
+    height: var(--h-plate);
+    padding: 0 9px;
     clip-path: polygon(
       0 0,
       100% 0,
@@ -65,16 +220,51 @@
       calc(100% - var(--cut)) 100%,
       0 100%
     );
-    padding: 4px 9px;
     border: none;
     background: var(--steel);
     color: var(--ash);
     font-family: var(--font-ui);
-    font-size: var(--fs-label);
+    font-size: var(--fs-body);
     line-height: 1;
     transition:
       background var(--dur-state) ease-out,
       color var(--dur-state) ease-out;
+  }
+
+  .footer__cup {
+    gap: 6px;
+    /* over the scrim, or the plate goes dead the moment the menu opens */
+    position: relative;
+    z-index: 2;
+  }
+
+  .footer__cup[data-state="none"]:hover:not(:disabled) {
+    color: var(--bone);
+  }
+
+  /* running, the same flood the sign in chip takes when its drawer is open */
+  .footer__cup[data-state="running"] {
+    background: var(--signal);
+    color: var(--void);
+  }
+
+  /* yellow has nowhere brighter to go, so the hover eases the plate back. the
+     mark stays the void, bone on yellow is the contrast bug */
+  .footer__cup[data-state="running"]:hover:not(:disabled) {
+    background: rgba(247, 255, 97, 0.8);
+  }
+
+  /* held, so the accent sits on the reading rather than under it. the clock
+     still accounts for a session that exists, it is just not running */
+  .footer__cup[data-state="paused"] {
+    color: var(--signal);
+  }
+
+  /* the assertion is only good on mains, so off them this is not a control */
+  .footer__cup:disabled {
+    background: var(--steel);
+    color: var(--slate);
+    opacity: 0.5;
   }
 
   .footer__quit:hover {

--- a/apps/menubar/src/lib/HandleField.svelte
+++ b/apps/menubar/src/lib/HandleField.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+  interface Props {
+    /** the drawer is open, rather than sitting shut at zero height */
+    open: boolean;
+    /** the request is out and the browser has not come back */
+    pending: boolean;
+    onsubmit: (handle: string) => void;
+    oncancel: () => void;
+  }
+
+  let { open, pending, onsubmit, oncancel }: Props = $props();
+
+  let value = $state("");
+  let input = $state<HTMLInputElement | null>(null);
+
+  const ready = $derived(value.trim().length > 0);
+
+  // the field stays mounted so the drawer can animate shut, so the caret has
+  // to follow the drawer rather than the mount
+  $effect(() => {
+    if (open) {
+      input?.focus();
+    } else {
+      input?.blur();
+      // a failed sign-in comes back here, and retyping a handle you already
+      // typed is the wrong thing to ask for
+      if (!pending) value = "";
+    }
+  });
+
+  function submit() {
+    if (!ready || pending) return;
+    onsubmit(value);
+  }
+
+  // escape belongs to the field while it is open, the panel takes it back after
+  function key(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      event.preventDefault();
+      oncancel();
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      submit();
+    }
+  }
+</script>
+
+<!-- the switch's construction, one frame with cells inset into it, so this
+     reads as a sibling of the toggle rather than as a web form -->
+<div class="field" data-ready={ready} data-pending={pending}>
+  <span class="field__cell">
+    <span class="field__at">@</span>
+    <input
+      bind:this={input}
+      bind:value
+      class="field__input"
+      type="text"
+      placeholder="name.bsky.social"
+      spellcheck="false"
+      autocapitalize="off"
+      autocomplete="off"
+      autocorrect="off"
+      disabled={pending}
+      aria-label="Atproto handle"
+      onkeydown={key}
+    />
+  </span>
+  <button
+    class="field__go"
+    disabled={!ready || pending}
+    aria-label="Sign in"
+    onclick={submit}
+  >
+    ↵
+  </button>
+</div>
+
+<style>
+  .field {
+    --frame: rgba(255, 255, 255, 0.22);
+
+    position: relative;
+    display: flex;
+    gap: 1px;
+    height: 26px;
+    padding: 1px;
+    background: var(--frame);
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% calc(100% - var(--cut)),
+      calc(100% - var(--cut)) 100%,
+      0 100%
+    );
+    transition: background var(--dur-state) ease-out;
+  }
+
+  /* the switch lights its frame when it is on, this lights it when it is yours */
+  .field:focus-within,
+  .field[data-pending="true"] {
+    --frame: rgba(247, 255, 97, 0.5);
+  }
+
+  .field__cell {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+    padding: 0 8px;
+    background: var(--steel);
+  }
+
+  /* the handle is typed without it, so the field carries it */
+  .field__at {
+    flex: none;
+    color: var(--signal);
+    font-family: var(--font-mono);
+    font-size: var(--fs-mono);
+  }
+
+  .field__input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: none;
+    color: var(--bone);
+    caret-color: var(--signal);
+    font-family: var(--font-mono);
+    font-size: var(--fs-mono);
+  }
+
+  .field__input::placeholder {
+    color: var(--slate);
+    opacity: 0.6;
+  }
+
+  /* the switch's lit cell doing the same job it does there, the half that is
+     live. the cut is one shorter so it stays parallel to the frame's */
+  .field__go {
+    flex: none;
+    width: 34px;
+    border: none;
+    padding: 0;
+    background: var(--steel);
+    color: #5c5c64;
+    clip-path: polygon(
+      0 0,
+      100% 0,
+      100% calc(100% - var(--cut) + 1px),
+      calc(100% - var(--cut) + 1px) 100%,
+      0 100%
+    );
+    font-family: var(--font-mono);
+    font-size: var(--fs-mono);
+    line-height: 1;
+    transition:
+      background var(--dur-state) ease-out,
+      color var(--dur-state) ease-out;
+  }
+
+  .field[data-ready="true"] .field__go {
+    background: var(--signal);
+    color: var(--void);
+  }
+
+  /* the switch runs its light around the whole frame, there is only room for
+     one edge here */
+  .field[data-pending="true"]::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: var(--hairline);
+    background: linear-gradient(90deg, transparent, var(--signal), transparent);
+    animation: sweep 1.4s linear infinite;
+  }
+
+  @keyframes sweep {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .field[data-pending="true"]::after {
+      background: var(--signal);
+      opacity: 0.5;
+      animation: none;
+    }
+  }
+</style>

--- a/apps/menubar/src/lib/Row.svelte
+++ b/apps/menubar/src/lib/Row.svelte
@@ -79,6 +79,8 @@
 <style>
   .row {
     --row-mark: var(--slate);
+    /* the frame around the mark, the handle field's resting value */
+    --mark-frame: rgba(255, 255, 255, 0.22);
 
     position: relative;
     display: flex;
@@ -110,6 +112,9 @@
 
   .row[data-active="true"] {
     --row-mark: var(--signal);
+    /* just under full, the accent without the glare. much below this and the
+       void underneath turns it olive rather than dimming it */
+    --mark-frame: rgba(247, 255, 97, 0.8);
   }
 
   .row[data-active="true"]::before {

--- a/apps/menubar/src/lib/Stack.svelte
+++ b/apps/menubar/src/lib/Stack.svelte
@@ -76,6 +76,7 @@
       data-anim={leaving.dir === "push" ? "out-to-left" : "out-to-right"}
       data-running={running}
       aria-hidden="true"
+      inert
     >
       {@render view(leaving.id)}
     </div>

--- a/apps/menubar/src/nav.svelte.ts
+++ b/apps/menubar/src/nav.svelte.ts
@@ -1,4 +1,4 @@
-export type ViewId = "root" | "account" | "sessions" | "model";
+export type ViewId = "root" | "account" | "atmosphere" | "sessions" | "model";
 
 /** views are pushed onto the root, never replacing it */
 class Nav {

--- a/apps/menubar/src/state.svelte.ts
+++ b/apps/menubar/src/state.svelte.ts
@@ -43,6 +43,16 @@ export type Atproto =
 export type Session = { id: string; name: string; createdAt: number };
 export type Sessions = { state: "unknown" } | { state: "ready"; sessions: Session[] };
 
+/** the power assertion, held by the menubar and not the daemon */
+export type Awake = {
+  active: boolean;
+  paused: boolean;
+  since: number | null;
+  until: number | null;
+  frozen: number | null;
+  ac: boolean;
+};
+
 export type Remote =
   | { state: "unknown" }
   | { state: "off" }
@@ -56,10 +66,13 @@ export const account = $state<{ value: Account }>({ value: { state: "unknown" } 
 export const atproto = $state<{ value: Atproto }>({ value: { state: "unknown" } });
 export const sessions = $state<{ value: Sessions }>({ value: { state: "unknown" } });
 export const remote = $state<{ value: Remote }>({ value: { state: "unknown" } });
+export const awake = $state<{ value: Awake }>({
+  value: { active: false, paused: false, since: null, until: null, frozen: null, ac: false },
+});
 
 /**
  * events only fire on a change, so every state has to be asked for once as
- * well. returns the teardown for all six listeners
+ * well. returns the teardown for all seven listeners
  */
 export function connect(): () => void {
   let connected = true;
@@ -102,6 +115,7 @@ export function connect(): () => void {
     sync<Atproto>("atproto://state", "atproto_state", (v) => (atproto.value = v)),
     sync<Sessions>("sessions://state", "sessions_state", (v) => (sessions.value = v)),
     sync<Remote>("remote://state", "remote_state", (v) => (remote.value = v)),
+    sync<Awake>("awake://state", "awake_state", (v) => (awake.value = v)),
   ];
 
   return () => {

--- a/apps/menubar/src/state.svelte.ts
+++ b/apps/menubar/src/state.svelte.ts
@@ -31,7 +31,14 @@ export type Atproto =
   | { state: "unknown" }
   | { state: "none" }
   | { state: "pending"; handle: string }
-  | { state: "session"; handle: string; did: string };
+  | {
+      state: "session";
+      handle: string;
+      did: string;
+      displayName?: string | null;
+      avatar?: string | null;
+      pds?: string | null;
+    };
 
 export type Session = { id: string; name: string; createdAt: number };
 export type Sessions = { state: "unknown" } | { state: "ready"; sessions: Session[] };

--- a/apps/menubar/src/state.svelte.ts
+++ b/apps/menubar/src/state.svelte.ts
@@ -27,6 +27,12 @@ export type Account =
   | { state: "none" }
   | { state: "local"; did: string; nickname: string };
 
+export type Atproto =
+  | { state: "unknown" }
+  | { state: "none" }
+  | { state: "pending"; handle: string }
+  | { state: "session"; handle: string; did: string };
+
 export type Session = { id: string; name: string; createdAt: number };
 export type Sessions = { state: "unknown" } | { state: "ready"; sessions: Session[] };
 
@@ -40,12 +46,13 @@ export const inference = $state<{ value: Inference }>({
   value: { power: "unknown", model: null, llama: null },
 });
 export const account = $state<{ value: Account }>({ value: { state: "unknown" } });
+export const atproto = $state<{ value: Atproto }>({ value: { state: "unknown" } });
 export const sessions = $state<{ value: Sessions }>({ value: { state: "unknown" } });
 export const remote = $state<{ value: Remote }>({ value: { state: "unknown" } });
 
 /**
  * events only fire on a change, so every state has to be asked for once as
- * well. returns the teardown for all five listeners
+ * well. returns the teardown for all six listeners
  */
 export function connect(): () => void {
   let connected = true;
@@ -85,6 +92,7 @@ export function connect(): () => void {
     sync<Health>("daemon://health", "daemon_health", (v) => (health.value = v)),
     sync<Inference>("inference://state", "inference_state", (v) => (inference.value = v)),
     sync<Account>("account://state", "account_state", (v) => (account.value = v)),
+    sync<Atproto>("atproto://state", "atproto_state", (v) => (atproto.value = v)),
     sync<Sessions>("sessions://state", "sessions_state", (v) => (sessions.value = v)),
     sync<Remote>("remote://state", "remote_state", (v) => (remote.value = v)),
   ];

--- a/apps/menubar/src/styles/base.css
+++ b/apps/menubar/src/styles/base.css
@@ -13,6 +13,16 @@
   outline: none;
 }
 
+/* the reset above kills every text behaviour, and a field is the one place
+   that needs them back */
+input {
+  font: inherit;
+  color: inherit;
+  user-select: text;
+  -webkit-user-select: text;
+  cursor: text;
+}
+
 html,
 body,
 #app {

--- a/apps/menubar/src/views/AccountView.svelte
+++ b/apps/menubar/src/views/AccountView.svelte
@@ -15,7 +15,19 @@
   const copier = new Copier();
   onDestroy(() => copier.dispose());
 
-  const local = $derived(account.value.state === "local" ? account.value : null);
+  // the daemon misses a tick and reports unknown, and an account already on
+  // screen should not blink out with it. the identity itself does not change
+  let held = $state(account.value.state === "local" ? account.value : null);
+
+  $effect(() => {
+    const at = account.value;
+    if (at.state === "local") held = at;
+    // no account is not a blip, and this view is of one that is gone
+    else if (at.state === "none") nav.pop();
+  });
+
+  // const, so the row below can narrow it inside its own handler
+  const local = $derived(held);
 
   // read once on open rather than polled, the daemon rewrites it only on a
   // `tiles data path` and this view is not on screen for long

--- a/apps/menubar/src/views/AtmosphereView.svelte
+++ b/apps/menubar/src/views/AtmosphereView.svelte
@@ -18,7 +18,20 @@
     did.dispose();
   });
 
-  const session = $derived(atproto.value.state === "session" ? atproto.value : null);
+  // the daemon misses a tick and reports unknown, and an account already on
+  // screen should not blink out with it. the identity itself does not change
+  let held = $state(atproto.value.state === "session" ? atproto.value : null);
+
+  $effect(() => {
+    const at = atproto.value;
+    if (at.state === "session") held = at;
+    // signed out is not a blip, and this view is of an account that is gone
+    else if (at.state === "none") nav.pop();
+  });
+
+  // const, so the rows below can narrow it inside their own handlers
+  const session = $derived(held);
+
   const name = $derived(session?.displayName?.trim() || null);
 
   // the scheme is the same for every one of them, the host is the part that says

--- a/apps/menubar/src/views/AtmosphereView.svelte
+++ b/apps/menubar/src/views/AtmosphereView.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+
+  import Avatar from "../lib/Avatar.svelte";
+  import CopyMark from "../lib/CopyMark.svelte";
+  import Navbar from "../lib/Navbar.svelte";
+  import Row from "../lib/Row.svelte";
+  import Zone from "../lib/Zone.svelte";
+  import { Copier } from "../lib/copy.svelte";
+  import { nav } from "../nav.svelte";
+  import { atproto, truncateMiddle } from "../state.svelte";
+
+  // one per row, so copying the did does not light the handle's mark
+  const handle = new Copier();
+  const did = new Copier();
+  onDestroy(() => {
+    handle.dispose();
+    did.dispose();
+  });
+
+  const session = $derived(atproto.value.state === "session" ? atproto.value : null);
+  const name = $derived(session?.displayName?.trim() || null);
+
+  // the scheme is the same for every one of them, the host is the part that says
+  // where the account actually lives
+  const host = $derived(session?.pds?.replace(/^https:\/\//, "") ?? null);
+</script>
+
+<Navbar title="Atmosphere Account" onback={() => nav.pop()} />
+
+<!-- no label, an avatar beside a name does not need one told -->
+<Zone>
+  <Row
+    size="large"
+    title={name ?? (session ? `@${session.handle}` : "—")}
+    dimmed={session === null}
+  >
+    {#snippet leading()}
+      <Avatar nickname={name ?? session?.handle ?? "?"} src={session?.avatar} size={26} />
+    {/snippet}
+  </Row>
+  <!-- the sub said what the name was, this says where the account is -->
+  <p class="note">This account lives on the server below, and Tiles reads it there directly</p>
+</Zone>
+
+<Zone label="Handle">
+  <Row
+    mono
+    title={session ? `@${session.handle}` : "—"}
+    dimmed={session === null}
+    onselect={session ? () => handle.copy(session.handle) : undefined}
+  >
+    {#snippet inline()}
+      <CopyMark copied={handle.copied} />
+    {/snippet}
+  </Row>
+</Zone>
+
+<Zone label="Decentralized ID">
+  <Row
+    mono
+    title={session ? truncateMiddle(session.did, 30, 10) : "—"}
+    dimmed={session === null}
+    onselect={session ? () => did.copy(session.did) : undefined}
+  >
+    {#snippet inline()}
+      <CopyMark copied={did.copied} />
+    {/snippet}
+  </Row>
+</Zone>
+
+<Zone label="Personal data server">
+  <!-- read with the profile, so it lands a beat after the identity does -->
+  <Row mono title={host ?? "—"} dimmed={host === null} />
+</Zone>
+
+<style>
+  /* the grey the row's sub used to carry, on its own line under the whole row */
+  .note {
+    padding: 2px var(--pad-x) 2px;
+    color: var(--slate);
+    font-size: var(--fs-body);
+    line-height: 1.35;
+  }
+</style>

--- a/apps/menubar/src/views/RootView.svelte
+++ b/apps/menubar/src/views/RootView.svelte
@@ -95,25 +95,38 @@
 
   const atmosphere = $derived.by(() => {
     switch (atproto.value.state) {
-      case "session":
+      case "session": {
+        // the name takes the title when there is one, and the handle carries
+        // the did off the row when it does
+        const name = atproto.value.displayName?.trim() || null;
         return {
-          name: atproto.value.handle,
-          title: `@${atproto.value.handle}`,
-          sub: truncateMiddle(atproto.value.did, 16, 6),
+          name: name ?? atproto.value.handle,
+          title: name ?? `@${atproto.value.handle}`,
+          sub: name ? `@${atproto.value.handle}` : truncateMiddle(atproto.value.did, 16, 6),
+          avatar: atproto.value.avatar ?? null,
         };
+      }
       case "pending":
         return {
           name: atproto.value.handle,
           title: `@${atproto.value.handle}`,
           sub: "Waiting for your browser",
+          avatar: null,
         };
       default:
-        return { name: "?", title: "Not connected", sub: "" };
+        return { name: "?", title: "Not connected", sub: "", avatar: null };
     }
   });
 
   const signedOut = $derived(atproto.value.state === "none");
   const signingIn = $derived(atproto.value.state === "pending");
+  const signedIn = $derived(atproto.value.state === "session");
+
+  // signed out the row opens the drawer, signed in it pushes, and mid-login it
+  // is neither
+  const enterAtmosphere = $derived(
+    signedOut ? askForHandle : signedIn ? () => nav.push("atmosphere") : undefined,
+  );
 
   let drawer = $state(false);
   let signInError = $state<string | null>(null);
@@ -252,14 +265,16 @@
     sub={atmosphere.sub}
     submono={atproto.value.state === "session"}
     dimmed={atproto.value.state === "unknown"}
-    onselect={signedOut ? askForHandle : undefined}
+    onselect={enterAtmosphere}
   >
     {#snippet leading()}
-      <Avatar nickname={atmosphere.name} />
+      <Avatar nickname={atmosphere.name} src={atmosphere.avatar} />
     {/snippet}
     {#snippet trailing()}
       {#if signedOut}
         <span class="signin" data-open={drawer}>Sign in</span>
+      {:else if signedIn}
+        <Chevron />
       {/if}
     {/snippet}
   </Row>
@@ -384,6 +399,12 @@
 
   .account:not(:first-of-type) {
     margin-top: 9px;
+  }
+
+  /* the zone label carries 5 of the 9 this wants, and a label under a label
+     needs the same step everything else separates on */
+  .account:first-of-type {
+    margin-top: 4px;
   }
 
   /* the row is the button, so this is a span. two buttons in one row is one

--- a/apps/menubar/src/views/RootView.svelte
+++ b/apps/menubar/src/views/RootView.svelte
@@ -7,6 +7,7 @@
   import Chip from "../lib/Chip.svelte";
   import CopyMark from "../lib/CopyMark.svelte";
   import Footer from "../lib/Footer.svelte";
+  import HandleField from "../lib/HandleField.svelte";
   import Masthead, { type Mode } from "../lib/Masthead.svelte";
   import ProviderMark from "../lib/ProviderMark.svelte";
   import Row from "../lib/Row.svelte";
@@ -16,7 +17,15 @@
   import { Copier } from "../lib/copy.svelte";
   import { contextLabel, describe } from "../lib/model";
   import { nav } from "../nav.svelte";
-  import { account, health, inference, remote, sessions, truncateMiddle } from "../state.svelte";
+  import {
+    account,
+    atproto,
+    health,
+    inference,
+    remote,
+    sessions,
+    truncateMiddle,
+  } from "../state.svelte";
 
   /** how many fit under the masthead before the panel gets tall */
   const PREVIEW = 3;
@@ -83,6 +92,54 @@
         return { name: "?", title: "—", sub: "" };
     }
   });
+
+  const atmosphere = $derived.by(() => {
+    switch (atproto.value.state) {
+      case "session":
+        return {
+          name: atproto.value.handle,
+          title: `@${atproto.value.handle}`,
+          sub: truncateMiddle(atproto.value.did, 16, 6),
+        };
+      case "pending":
+        return {
+          name: atproto.value.handle,
+          title: `@${atproto.value.handle}`,
+          sub: "Waiting for your browser",
+        };
+      default:
+        return { name: "?", title: "Not connected", sub: "" };
+    }
+  });
+
+  const signedOut = $derived(atproto.value.state === "none");
+  const signingIn = $derived(atproto.value.state === "pending");
+
+  let drawer = $state(false);
+  let signInError = $state<string | null>(null);
+
+  // the browser takes key off the panel, so the drawer would come back open
+  // over an account that is already signed in
+  $effect(() => {
+    if (atproto.value.state === "session") drawer = false;
+  });
+
+  function askForHandle() {
+    drawer = !drawer;
+    if (!drawer) signInError = null;
+  }
+
+  // the daemon holds this open for the whole browser round trip, so the await
+  // outlives the panel being on screen
+  async function signIn(handle: string) {
+    signInError = null;
+    try {
+      await invoke("atproto_login", { handle });
+      drawer = false;
+    } catch (err) {
+      signInError = String(err);
+    }
+  }
 
   const recent = $derived(sessions.value.state === "ready" ? sessions.value.sessions : []);
   // pushing would show exactly what is already on screen
@@ -170,7 +227,8 @@
 
 <Masthead {mode} {on} pending={busy} disabled={health.value.state !== "up"} ontoggle={toggle} />
 
-<Zone label="Tiles Account">
+<Zone label="Accounts">
+  <h3 class="account">Tiles</h3>
   <Row
     size="large"
     title={identity.title}
@@ -186,6 +244,41 @@
       {#if account.value.state === "local"}<Chevron />{/if}
     {/snippet}
   </Row>
+
+  <h3 class="account">Atmosphere</h3>
+  <Row
+    size="large"
+    title={atmosphere.title}
+    sub={atmosphere.sub}
+    submono={atproto.value.state === "session"}
+    dimmed={atproto.value.state === "unknown"}
+    onselect={signedOut ? askForHandle : undefined}
+  >
+    {#snippet leading()}
+      <Avatar nickname={atmosphere.name} />
+    {/snippet}
+    {#snippet trailing()}
+      {#if signedOut}
+        <span class="signin" data-open={drawer}>Sign in</span>
+      {/if}
+    {/snippet}
+  </Row>
+
+  <!-- the panel's height follows its content, so opening this grows the window
+       with it, one resize per frame the way a push does -->
+  <div class="drawer" data-open={drawer || signingIn}>
+    <div class="drawer__clip" inert={!drawer && !signingIn}>
+      <div class="drawer__body">
+        <HandleField
+          open={drawer && !signingIn}
+          pending={signingIn}
+          onsubmit={signIn}
+          oncancel={() => (drawer = false)}
+        />
+        {#if signInError}<p class="drawer__error">{signInError}</p>{/if}
+      </div>
+    </div>
+  </div>
 </Zone>
 
 <Zone label="Model" dimmed={!canShare}>
@@ -267,6 +360,78 @@
 <Footer {note} alert={health.value.state === "down"} />
 
 <style>
+  /* the zone's rule runs full bleed and carries a zone label, so a rule that
+     is inset and interrupted by its own name is the level under it */
+  .account {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    margin-bottom: 5px;
+    padding: 0 var(--pad-x);
+    color: var(--slate);
+    font-size: var(--fs-chip);
+    font-weight: 500;
+    letter-spacing: var(--tracking-chip);
+    opacity: 0.8;
+  }
+
+  .account::after {
+    content: "";
+    flex: 1;
+    height: var(--hairline);
+    background: var(--rule);
+  }
+
+  .account:not(:first-of-type) {
+    margin-top: 9px;
+  }
+
+  /* the row is the button, so this is a span. two buttons in one row is one
+     too many, and the rail already says which row is live */
+  .signin {
+    flex: none;
+    clip-path: polygon(0 0, 100% 0, 100% calc(100% - 3px), calc(100% - 3px) 100%, 0 100%);
+    padding: 3px 7px;
+    background: var(--steel);
+    color: var(--row-mark, var(--ash));
+    font-size: var(--fs-label);
+    font-weight: 500;
+    transition:
+      background var(--dur-state) ease-out,
+      color var(--dur-state) ease-out;
+  }
+
+  .signin[data-open="true"] {
+    background: var(--signal);
+    color: var(--void);
+  }
+
+  .drawer {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows var(--dur-push) var(--ease-push);
+  }
+
+  .drawer[data-open="true"] {
+    grid-template-rows: 1fr;
+  }
+
+  /* the padding rides inside the clip, so a shut drawer is exactly zero */
+  .drawer__clip {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .drawer__body {
+    padding: 3px var(--pad-x) 5px;
+  }
+
+  .drawer__error {
+    padding-top: 5px;
+    color: var(--alert);
+    font-size: var(--fs-label);
+  }
+
   /* the ticket's own line, at the width the truncated one lands on */
   .ticket-skeleton {
     width: 186px;


### PR DESCRIPTION
### New stuff
- shows atmosphere account in menu bar
- can login using your handle
- a pushed view like tiles account showing handle, PDS and DID
- fetches profile picture and display name from bsky entries in PDS
- Keep awake while plugged in
- set timers or indefinite with pause

### Notes:
- PDS lookup has been implemented in the client for now, but we should move that to the daemon when appropriate

### Screenshot
<img width="383" height="539" alt="Screenshot 2026-09-09 at 10 11 05 AM" src="https://github.com/user-attachments/assets/90e92a50-cdb0-4a05-87a9-c778febd83f8" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791517199&installation_model_id=435623&pr_number=203&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F203&signature=aef06e52b8993d4935a1a59bf70054220b323b05c742d82e0a9a1e6a2b85caa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->