### PR TITLE
Edit the modelfile from the app

### DIFF
--- a/tiles/src/daemon/agent.rs
+++ b/tiles/src/daemon/agent.rs
@@ -52,6 +52,7 @@ pub fn agent_router() -> Router<Arc<AppState>> {
         .route("/v1/tilekit/agent/end_session", get(end_current_session))
         .route("/v1/tilekit/agent/state", get(agent_state))
         .route("/v1/tilekit/agent/prompt", post(process_chat_prompt))
+        .route("/v1/tilekit/agent/reload", get(reload_agent))
 }
 
 async fn start_agent(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
@@ -83,6 +84,28 @@ pub fn get_agent_start_params(provider: impl ConfigProvider) -> Result<(String, 
     let system_prompt = default_modelfile.system.clone().unwrap_or("".to_owned());
 
     Ok((modelname, system_prompt))
+}
+
+/// Drop the running agent and start a fresh one. The modelfile is only read at
+/// start, so this is what applies an edited one without restarting the daemon.
+async fn reload_agent(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
+    // before taking the old one down, so a bad modelfile leaves it running
+    let (modelname, system_prompt) = get_agent_start_params(DefaultProvider)?;
+
+    let mut agent = state.agent.lock().await;
+
+    // pi is setsid into its own session and PiAgent has no Drop, so letting the
+    // handle go would leave the process behind
+    if let Some(current) = agent.take() {
+        let (mut process, _, _) = current.split();
+        let _ = process.kill().await;
+    }
+
+    let pi_agent = pi::new(&modelname, &system_prompt, PY_PORT)
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+    *agent = Some(pi_agent);
+
+    Ok(ApiResponse::success(json!({"message": "reloaded agent"})))
 }
 
 #[debug_handler]

--- a/tiles/src/daemon/mod.rs
+++ b/tiles/src/daemon/mod.rs
@@ -47,6 +47,7 @@ use tower_http::cors::CorsLayer;
 pub mod account;
 pub mod agent;
 pub mod atproto;
+pub mod modelfile;
 pub mod server;
 pub mod session;
 use crate::{
@@ -311,6 +312,7 @@ pub async fn start_server(port: Option<u32>, with_ui: bool, show_ui: bool) -> Re
         .route("/remote-status", get(show_remote_status))
         .route("/connect-remote", get(connect_remote_inference))
         .merge(agent_router())
+        .merge(modelfile::modelfile_router())
         .merge(server_router())
         .merge(account_router())
         .merge(session_router())

--- a/tiles/src/daemon/modelfile.rs
+++ b/tiles/src/daemon/modelfile.rs
@@ -1,0 +1,79 @@
+//! Reading and writing the modelfile the agent starts from
+//!
+//! The shipped modelfile installs into the lib dir owned by root, so an edit is
+//! written to the user's data dir instead and wins from there. Nothing here
+//! touches a running agent: see `/v1/tilekit/agent/reload` for that.
+
+use std::fs;
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    routing::{get, put},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    daemon::{ApiResponse, AppError, AppState},
+    repl::{get_default_modelfile, user_modelfile_path},
+    utils::config::DefaultProvider,
+};
+
+#[derive(Serialize)]
+struct ModelfileData {
+    content: String,
+    /// false while the shipped one is still in use, so the UI can say so
+    edited: bool,
+}
+
+#[derive(Deserialize)]
+struct ModelfileRequest {
+    content: String,
+}
+
+pub fn modelfile_router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/v1/tilekit/modelfile", get(read_modelfile))
+        .route("/v1/tilekit/modelfile", put(write_modelfile))
+}
+
+async fn read_modelfile() -> Result<Json<ApiResponse<ModelfileData>>, AppError> {
+    let path =
+        get_default_modelfile(DefaultProvider).map_err(|e| AppError::NotFound(e.to_string()))?;
+
+    let content = fs::read_to_string(&path)
+        .map_err(|e| AppError::NotFound(format!("Could not read {}: {e}", path.display())))?;
+
+    let edited = user_modelfile_path(&DefaultProvider)
+        .map(|user| user == path)
+        .unwrap_or(false);
+
+    Ok(ApiResponse::success(ModelfileData { content, edited }))
+}
+
+async fn write_modelfile(
+    Json(payload): Json<ModelfileRequest>,
+) -> Result<Json<ApiResponse<ModelfileData>>, AppError> {
+    // the parser insists on a FROM, so this also catches a modelfile that would
+    // leave the agent with no model to start
+    tilekit::modelfile::parse(&payload.content)
+        .map_err(|e| AppError::CannotProcess(format!("Not a valid modelfile: {e}")))?;
+
+    let path = user_modelfile_path(&DefaultProvider)
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            AppError::InternalServerError(format!("Could not create {parent:?}: {e}"))
+        })?;
+    }
+
+    fs::write(&path, &payload.content).map_err(|e| {
+        AppError::InternalServerError(format!("Could not write {}: {e}", path.display()))
+    })?;
+
+    Ok(ApiResponse::success(ModelfileData {
+        content: payload.content,
+        edited: true,
+    }))
+}

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -628,9 +628,19 @@ async fn wait_until_server_is_up() {
     }
 }
 
+/// where an edited modelfile is kept. the shipped one sits in the lib dir, which
+/// is root owned on an installed copy, so nothing running as the user can write it
+pub fn user_modelfile_path(provider: &impl ConfigProvider) -> Result<PathBuf> {
+    Ok(provider.get_data_dir()?.join("modelfile"))
+}
+
 pub fn get_default_modelfile(provider: impl ConfigProvider) -> Result<PathBuf> {
-    let path = provider.get_lib_dir()?.join("modelfiles/gemma-4-12b-gguf");
-    Ok(path)
+    let edited = user_modelfile_path(&provider)?;
+    if edited.is_file() {
+        return Ok(edited);
+    }
+
+    Ok(provider.get_lib_dir()?.join("modelfiles/gemma-4-12b-gguf"))
 }
 
 async fn load_model_in_py(
@@ -1319,11 +1329,70 @@ mod tests {
     use crate::core::chats::tests::create_user;
     use rusqlite::Connection;
 
+    /// the real provider points at the running machine, where an edited
+    /// modelfile may or may not be sitting in the data dir
+    #[derive(Clone)]
+    struct TempDirs {
+        data: std::path::PathBuf,
+        lib: std::path::PathBuf,
+    }
+
+    impl ConfigProvider for TempDirs {
+        fn get_config_dir(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.data.clone())
+        }
+        fn get_or_create_config_dir(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.data.clone())
+        }
+        fn get_data_dir(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.data.clone())
+        }
+        fn get_or_create_data_dir(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.data.clone())
+        }
+        fn get_user_data_dir(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.data.clone())
+        }
+        fn get_lib_dir(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.lib.clone())
+        }
+        fn get_user_bin_dir(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.data.clone())
+        }
+        fn get_user_bin_path(&self) -> anyhow::Result<PathBuf> {
+            Ok(self.data.clone())
+        }
+    }
+
+    fn temp_dirs() -> (tempfile::TempDir, TempDirs) {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = TempDirs {
+            data: tmp.path().join("data"),
+            lib: tmp.path().join("lib"),
+        };
+        std::fs::create_dir_all(&dirs.data).unwrap();
+        std::fs::create_dir_all(dirs.lib.join("modelfiles")).unwrap();
+        (tmp, dirs)
+    }
+
     #[test]
-    fn default_modelfile_uses_platform_default() {
-        let path =
-            get_default_modelfile(DefaultProvider).expect("default modelfile should resolve");
+    fn the_shipped_modelfile_is_used_when_nothing_was_edited() {
+        let (_tmp, dirs) = temp_dirs();
+
+        let path = get_default_modelfile(dirs).expect("default modelfile should resolve");
+
         assert!(path.ends_with("modelfiles/gemma-4-12b-gguf"));
+    }
+
+    #[test]
+    fn an_edited_modelfile_wins_over_the_shipped_one() {
+        let (_tmp, dirs) = temp_dirs();
+        let edited = user_modelfile_path(&dirs).unwrap();
+        std::fs::write(&edited, "FROM somewhere/else\n").unwrap();
+
+        let path = get_default_modelfile(dirs).expect("default modelfile should resolve");
+
+        assert_eq!(path, edited);
     }
 
     #[test]


### PR DESCRIPTION
The System Message setting in the chat UI never did anything. Its value was stored and rendered in the thread but never sent anywhere, because the Tilekit prompt call posts only the message text and Pi supplies its own system prompt.

The modelfile is what actually decides both: `FROM` names the model, `SYSTEM` becomes the prompt Pi is spawned with. This makes it editable.

## Where the edited file lives

The shipped modelfile installs into the lib dir as `root:wheel` and the daemon runs as the user, so it cannot be written in place. An edit is written to `<data_dir>/modelfile` instead and wins from there, leaving the shipped copy as the fallback.

This is hooked at `get_default_modelfile`, which is the single function every consumer already goes through, so a saved modelfile becomes the default everywhere and not just for the chat UI:

- `daemon/agent.rs` - what the agent starts from
- `repl.rs:127` - `tiles run` with no argument uses it as the modelfile
- `repl.rs:121` - `tiles run <file>` falls back to it for the system prompt

## Reloading

The modelfile is only read when the agent starts, and `/agent/start` is a no-op once an agent exists, so an edit previously needed the whole daemon restarted. `/v1/tilekit/agent/reload` drops the running agent and starts a fresh one from the new file.

Pi is `setsid` into its own session and `PiAgent` has no `Drop`, so the old process is killed rather than merely dropped. Verified that the pid changes, the old one dies, and exactly one Pi process remains.

## Endpoints

- `GET /v1/tilekit/modelfile` - the current modelfile and whether it is edited or as shipped
- `PUT /v1/tilekit/modelfile` - parses before writing, so a broken modelfile is refused rather than stored and discovered at the next start
- `GET /v1/tilekit/agent/reload`

## Testing

Verified against a running daemon: a `PUT` with a marker in its `SYSTEM` block, then a reload, and the new Pi process carries the marker in its `--append-system-prompt` argument. Invalid modelfiles are refused with the parser's own reason and nothing is written.

The existing `default_modelfile_uses_platform_default` test asserted against the real machine, which this change makes environment dependent, so it is replaced with two temp-dir tests covering both branches of the precedence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791575823&installation_model_id=435623&pr_number=204&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F204&signature=5f3677108d52617ad0afd17b678a792008a9b7efdb2a405f86945c4be6d3574c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->