### PR TITLE
Share a session over HTTP

### DIFF
--- a/tiles/src/core/account/atproto.rs
+++ b/tiles/src/core/account/atproto.rs
@@ -326,11 +326,14 @@ pub fn fetch_logged_in_data(conn: &Connection) -> Result<Option<AtprotoAuthData>
 
 //TODO: Move the login check to common fn
 // TODO: Add tests for share session plss
+/// Publishes a session snapshot to the user's PDS and returns the link to it.
+/// A private share encrypts the record and carries the key in the URL fragment,
+/// which never leaves the browser.
 pub async fn share_session(
     conn: &Connection,
     shared_session: &SessionSnapshotRecord,
     is_private: bool,
-) -> Result<()> {
+) -> Result<String> {
     if let Some(auth_data) = fetch_logged_in_data(conn)? {
         let (client, mem_session_store) = create_oauth_client()?;
         let session: Session = serde_json::from_str(&auth_data.session)?;
@@ -344,7 +347,7 @@ pub async fn share_session(
         } else {
             "Writing to PDS and generating link..."
         };
-        println!("{}", write_info);
+        info!("{}", write_info);
         let oauth_session = client
             .restore(&did_struct)
             .await
@@ -406,7 +409,7 @@ pub async fn share_session(
             shareable_base_url
         };
 
-        println!("successfully posted at {}", shareable_url);
+        info!("Shared session posted to the PDS");
 
         // Updating the session token
         let session = mem_session_store
@@ -426,11 +429,12 @@ pub async fn share_session(
         };
 
         upsert_auth_data(conn, &auth_data)?;
+
+        Ok(shareable_url)
     } else {
         info!("No logged-in user, please login");
-        return Err(anyhow!("NOT_LOGGED_IN"));
+        Err(anyhow!("NOT_LOGGED_IN"))
     }
-    Ok(())
 }
 
 fn create_oauth_client() -> Result<(TOAuthClient, MemorySessionStore)> {

--- a/tiles/src/daemon/atproto.rs
+++ b/tiles/src/daemon/atproto.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use axum::{
     Json, Router,
+    extract::Path,
     response::IntoResponse,
     routing::{get, post},
 };
@@ -14,14 +15,24 @@ use serde_json::json;
 use crate::{
     core::{
         account::atproto,
+        chats::fetch_chats_by_session_id,
         storage::db::{Dbconn, get_db_conn},
     },
     daemon::{ApiResponse, AppError, AppState},
+    utils::lexicons::SessionSnapshotRecord,
 };
 
 #[derive(Serialize, Deserialize)]
 pub struct AtLoginReq {
     user_handle: String,
+}
+
+#[derive(Deserialize)]
+pub struct ShareSessionReq {
+    /// A private share is encrypted before it goes to the PDS, and the key
+    /// rides in the link's fragment rather than in the record
+    #[serde(default)]
+    is_private: bool,
 }
 // atproto apis needed
 // login, logout
@@ -30,10 +41,71 @@ pub fn atproto_router() -> Router<Arc<AppState>> {
         .route("/v1/tilekit/atproto/login", post(login))
         .route("/v1/tilekit/atproto/logout", post(logout))
         .route("/v1/tilekit/atproto/status", get(status))
-    // .route(
-    //     "/v1/tilekit/atproto/share-session/{session-id}",
-    //     get(share_session),
-    // )
+        .route(
+            "/v1/tilekit/atproto/share-session/{session_id}",
+            post(share_session),
+        )
+}
+
+/// Publishes a session to the user's PDS and hands back the link. Posting
+/// rather than getting, because it writes a record every time it is called.
+#[debug_handler]
+pub async fn share_session(
+    Path(session_id): Path<String>,
+    Json(request): Json<ShareSessionReq>,
+) -> Result<impl IntoResponse, AppError> {
+    let chat_db_conn = get_db_conn(&crate::core::storage::db::DBTYPE::CHAT)
+        .map_err(|e| AppError::CannotProcess(e.to_string()))?;
+    let delta_chats = fetch_chats_by_session_id(&chat_db_conn, &session_id)
+        .map_err(|e| AppError::CannotProcess(e.to_string()))?;
+
+    let session = delta_chats
+        .sessions
+        .first()
+        .ok_or_else(|| AppError::NotFound(format!("No session {session_id}")))?;
+
+    // the snapshot is what gets published, and sessions from before it existed
+    // have nothing to publish
+    let snapshot = session.snapshot.as_ref().ok_or_else(|| {
+        AppError::CannotProcess("This session predates snapshots and cannot be shared".to_owned())
+    })?;
+
+    let shared_session: SessionSnapshotRecord =
+        serde_json::from_str(snapshot).map_err(|e| AppError::CannotProcess(e.to_string()))?;
+
+    let is_private = request.is_private;
+
+    // rusqlite's Connection is not Sync, so a share that holds one across its
+    // awaits cannot be a Send future, which is what axum wants. Keeping the
+    // whole thing on one blocking thread with a runtime of its own sidesteps
+    // that without threading a connection pool through the atproto code
+    let url = tokio::task::spawn_blocking(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        runtime.block_on(async {
+            let conn = get_db_conn(&crate::core::storage::db::DBTYPE::COMMON)?;
+
+            atproto::share_session(&conn, &shared_session, is_private).await
+        })
+    })
+    .await
+    .map_err(|e| AppError::InternalServerError(format!("Share task failed: {e}")))?
+    .map_err(|e| {
+        if e.to_string() == "NOT_LOGGED_IN" {
+            AppError::CannotProcess(
+                "Sharing needs an ATmosphere login, the session is stored on your PDS".to_owned(),
+            )
+        } else {
+            AppError::InternalServerError(e.to_string())
+        }
+    })?;
+
+    Ok(ApiResponse::success(json!({
+        "url": url,
+        "is_private": is_private
+    })))
 }
 
 #[debug_handler]

--- a/tiles/src/repl.rs
+++ b/tiles/src/repl.rs
@@ -813,13 +813,17 @@ async fn process_share_session(
                 println!("Please enter your ATmosphere handle (ex: john.bsky.team)");
                 stdin.read_line(&mut input)?;
                 login(input.trim()).await?;
-                share_session(&conn.common, &shared_session, is_private).await?;
+
+                let url = share_session(&conn.common, &shared_session, is_private).await?;
+
+                println!("successfully posted at {}", url);
             }
         }
         Err(err) => {
             eprintln!("Failed to share session due to {:?}", err)
         }
-        Ok(_) => {
+        Ok(url) => {
+            println!("successfully posted at {}", url);
             info!("Session shared successfully")
         }
     }


### PR DESCRIPTION
The REPL could already publish a session snapshot to the user's PDS through `/share`, but nothing else could. This puts the same capability behind `POST /v1/tilekit/atproto/share-session/{session_id}`, which the commented-out route in `atproto_router` had been holding a place for.

## Returning the link

`share_session` only `println!`d the shareable URL, which is no use to an HTTP caller, so it now returns it and the REPL does the printing. Its two progress lines become `info!` lines, since the daemon calls it too and stdout is not where a daemon talks.

`POST` rather than `GET`, because it writes a record to the PDS every time it is called.

## The Send problem

`rusqlite::Connection` is not `Sync`, so a handler holding one across the awaits inside `share_session` cannot produce the `Send` future axum requires. The REPL gets away with it by being single threaded.

Rather than thread a connection pool through the atproto code for one call site, the share runs on a single blocking thread with a current-thread runtime of its own, and opens its connection inside that thread.

## Behaviour

- Unknown session id gives a 404 naming it.
- A session with no snapshot (they predate the snapshot column) is refused with a reason rather than a panic, matching the REPL's "Older sessions are not supported".
- `NOT_LOGGED_IN` is turned into a message about needing an ATmosphere login, since sharing writes to the user's own PDS.
- The response carries the URL and the privacy flag back.

## Testing

Verified against a running daemon: the route is reachable, an unknown session returns `{"reason":"No session does-not-exist"}`, and the ATproto status endpoint confirms the login path.

I deliberately did **not** run a real share end to end, because that publishes a record to a live personal PDS. Worth doing once before this merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791576525&installation_model_id=435623&pr_number=205&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F205&signature=a9ec2a51bc5b89df04f4dce572eef3bbaa6da43d8ec043b41f6a5eeb86b770e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->