### PR TITLE
Point the bundled chat UI at the modelfile and share work

### DIFF
--- a/apps/menubar/ui.pin
+++ b/apps/menubar/ui.pin
@@ -1,4 +1,4 @@
 # The chat UI this app carries. Bump the commit to ship a newer one, the
 # build fetches exactly this and nothing else.
 repo=https://github.com/tilesprivacy/tiles-ui.git
-commit=43cd724407f0bb747af8195fe9276ac039b1d51b
+commit=9483c4832e07e20a43bfb85a259650f6625a0d6d


### PR DESCRIPTION
`apps/menubar/ui.pin` still named `43cd724`, which predates both UI commits that back the features now merged into canary. A build made against it would carry the new daemon endpoints with a UI that has neither the Modelfile settings field nor the share button.

Bumps the pin to `9483c48`, picking up:

- `a055772` edit the modelfile in settings
- `9483c48` share a chat to the ATmosphere, and drop the tab strip

One line. Needed before the next pkg build, since `bundle-ui.sh` fetches exactly the pinned commit and never the latest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791576848&installation_model_id=435623&pr_number=206&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F206&signature=52eb23c85d3db3f9dbea8d107b107f5b1d0c69a66ba79c23a6bb281fd8f47274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->