### PR TITLE
The build leaves no stray Tiles.app behind

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -181,3 +181,15 @@ pkgbuild --root "${PKG_APP_STAGE}" --install-location /Applications --component-
 # and anything at the top of it lands at the root of the volume. it also keeps a
 # stray copy of the app out of Spotlight and out of the apps drawer
 rm -rf "${PKG_APP_STAGE}"
+
+# tauri leaves its own copy behind too, and an installed Tiles then shares the
+# apps drawer with a build artefact. the packaged copy is the one to launch
+rm -rf "target/${TARGET}/bundle/macos/Tiles.app"
+
+# Launch Services indexes an app the moment it appears and keeps the entry after
+# it is gone, so both copies have to be withdrawn or they haunt the drawer
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+if [[ -x "${LSREGISTER}" ]]; then
+  "${LSREGISTER}" -u "${PWD}/${PKG_APP_STAGE}/Tiles.app" 2>/dev/null || true
+  "${LSREGISTER}" -u "${PWD}/target/${TARGET}/bundle/macos/Tiles.app" 2>/dev/null || true
+fi


### PR DESCRIPTION
A packaging run produces two app copies besides the one that goes into the pkg:

- `pkgapp/Tiles.app`, the staging root, already cleaned up
- `target/release/bundle/macos/Tiles.app`, tauri's own output, which stayed

Because macOS indexes any `.app` it finds on disk, an installed Tiles ended up sharing the apps drawer with a build artefact. It has caused repeated confusion about which Tiles is the real one, and `tiles uninstall` can't help, since a build artefact in a git checkout is not an install and an uninstaller has no business deleting it.

Launch Services also keeps its registration after the file is gone, which is why paths that no longer existed kept showing up. Deleting the copies is not enough on its own, so both are withdrawn with `lsregister -u`.

`lsregister` is guarded on being executable and both calls tolerate failure, so this is a no-op anywhere it isn't present.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791581684&installation_model_id=435623&pr_number=208&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F208&signature=f993b06ad9f2b2741c8b59debdb1665a3217d8cf9018f1ef7c8be220020e8370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->