### PR TITLE
DNS when a nameserver has an interface scope

### DIFF
--- a/tiles/src/core/account/atproto.rs
+++ b/tiles/src/core/account/atproto.rs
@@ -28,6 +28,8 @@ use tokio::{process::Command, sync::oneshot};
 use std::error::Error;
 
 use hickory_resolver::TokioResolver;
+use hickory_resolver::config::{NameServerConfig, ResolverConfig};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 
 use crate::{
     core::storage::db::{Dbconn, get_db_conn},
@@ -77,22 +79,48 @@ struct HickoryDnsTxtResolver {
     resolver: TokioResolver,
 }
 
+/// The nameservers macOS hands out, minus the ones that cannot be used.
+///
+/// System Configuration reports a router's link-local IPv6 resolver with the
+/// interface it belongs to, as `fe80::1%en0`, and the zone makes it unparseable
+/// as a plain address. hickory treats that as fatal and drops the whole config,
+/// so a working IPv4 resolver sitting next to it is lost with it. Reading the
+/// same list and skipping only what will not parse keeps the usable ones.
+fn nameservers_from_resolv_conf() -> Option<ResolverConfig> {
+    let text = std::fs::read_to_string("/etc/resolv.conf").ok()?;
+    let mut nameservers = vec![];
+
+    for line in text.lines() {
+        let Some(address) = line.trim().strip_prefix("nameserver") else {
+            continue;
+        };
+
+        // a scoped address is only reachable through the interface it names,
+        // which is not something this resolver can carry, so it goes
+        if let Ok(ip) = address.trim().parse() {
+            nameservers.push(NameServerConfig::udp_and_tcp(ip));
+        }
+    }
+
+    (!nameservers.is_empty()).then(|| ResolverConfig::from_parts(None, vec![], nameservers))
+}
+
 impl HickoryDnsTxtResolver {
     fn new() -> Result<Self> {
-        let build_resolver = if let Ok(resolver_builder) = TokioResolver::builder_tokio() {
-            resolver_builder.build()
-        } else {
-            return Err(anyhow!(
-                "Failed to resolve DNS, please check your internet connection"
-            ));
-        };
-        if let Ok(resolved) = build_resolver {
-            Ok(Self { resolver: resolved })
-        } else {
-            Err(anyhow!(
-                "Failed to resolve DNS, please check your internet connection"
-            ))
+        if let Ok(builder) = TokioResolver::builder_tokio()
+            && let Ok(resolver) = builder.build()
+        {
+            return Ok(Self { resolver });
         }
+
+        let config = nameservers_from_resolv_conf().ok_or_else(|| {
+            anyhow!("Failed to resolve DNS, please check your internet connection")
+        })?;
+
+        TokioResolver::builder_with_config(config, TokioRuntimeProvider::default())
+            .build()
+            .map(|resolver| Self { resolver })
+            .map_err(|_e| anyhow!("Failed to resolve DNS, please check your internet connection"))
     }
 }
 


### PR DESCRIPTION
Sharing a chat failed with `Failed to resolve DNS, please check your internet connection` on a network whose router advertises a link-local IPv6 resolver.

## Not a Tilekit problem

The obvious suspicion was the daemon, or the `spawn_blocking` wrapper the share runs inside. It is neither. Building the resolver both ways gives the same result:

```
MULTI_THREAD (repl-like)       => Err("failed to parse nameserver address: invalid IP address syntax")
SPAWN_BLOCKING+CURRENT_THREAD  => Err("failed to parse nameserver address: invalid IP address syntax")
```

`tiles run` then `/share` fails identically on such a network. The REPL only looked healthier because sharing never got far enough to reach the resolver before.

## The cause

On Apple targets hickory reads nameservers from System Configuration and calls `IpAddr::from_str` on each:

```rust
let addr = IpAddr::from_str(&Cow::from(&*n))
    .map_err(|e| format!("failed to parse nameserver address: {e}"))?;
```

macOS reports a router's link-local resolver together with the interface it belongs to, `fe80::bafb:b3ff:fee6:dd12%en0`, and the zone makes it unparseable as a plain address. The `?` throws away the entire config, so the working `192.168.0.1` next to it is lost as well.

Nothing about this is exotic. Any router advertising IPv6 DNS produces it.

## The fix

On that failure the same list is read again and entries that will not parse are skipped instead of being allowed to sink the rest. A scoped address is only reachable through the interface it names, which this resolver has no way to carry, so dropping it costs nothing.

No third-party resolver is used as a fallback. That would have been the easy fix and the wrong one for a local-first product: it would quietly send every handle lookup to someone else's DNS.

## Testing

Verified against the real network and a real record. The system path still fails, the fallback finds the one usable nameserver, and the TXT lookup the handle resolver depends on returns the expected DID:

```
system config    => Err("failed to parse nameserver address: invalid IP address syntax")
fallback servers => 1
TXT lookup       => ok, ["_atproto.pimtron.dev. 300 IN TXT did=did:plc:kdcc475mwmfd7ehlvhqxgrqr"]
```

Full suite passes apart from the pre-existing `daemon::account::tests::test_create_account` failure, which also fails on a clean canary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791582330&installation_model_id=435623&pr_number=209&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F209&signature=06563cc6b49416e7e17fffd03deb3781e6424c785155df4e8ad421487e39392b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->