### PR TITLE
Snapshots built from what Pi reported

### DIFF
--- a/tiles/src/core/chats.rs
+++ b/tiles/src/core/chats.rs
@@ -90,6 +90,27 @@ pub struct DeltaChat {
     pub sessions: Vec<Session>,
 }
 
+/// Adds one finished turn to a session's snapshot, starting the snapshot if the
+/// session has none yet.
+///
+/// This is how a session gets the same snapshot the REPL keeps: built from what
+/// Pi reported, so the thinking and the tool calls survive. Rebuilding from the
+/// chat rows afterwards cannot recover either, because only the final text of a
+/// turn is ever stored.
+pub fn append_turn_to_snapshot(conn: &Connection, session_id: &str, turn: Turn) -> Result<()> {
+    let session = fetch_session(conn, session_id)?;
+
+    let mut record: SessionSnapshotRecord = match session.snapshot.as_deref() {
+        Some(stored) => serde_json::from_str(stored)?,
+        None => SessionSnapshotRecord::new(&session.name, &session.id),
+    };
+
+    record.turns.push(turn);
+    update_snapshot(conn, session_id, serde_json::to_string(&record)?)?;
+
+    Ok(())
+}
+
 /// Rebuilds a snapshot from the stored rows.
 ///
 /// The REPL keeps a snapshot as it goes, built from the events Pi hands it. The

--- a/tiles/src/daemon/agent.rs
+++ b/tiles/src/daemon/agent.rs
@@ -3,11 +3,14 @@
 use crate::{
     core::agent::{
         pi::{self, PiAgent, handle_graceful_exit},
-        types::PiResponse,
+        types::{PiAgentEndEvent, PiMsgContent, PiResponse},
     },
+    core::chats::append_turn_to_snapshot,
+    core::storage::db::{DBTYPE, get_db_conn},
     daemon::{ApiResponse, AppError, AppState},
     repl::{get_default_modelfile, model_spec},
     utils::config::{ConfigProvider, DefaultProvider, PY_PORT},
+    utils::lexicons::Turn,
 };
 
 // use async_stream::stream;
@@ -29,6 +32,10 @@ use tokio_util::sync::CancellationToken;
 #[derive(Deserialize)]
 struct PromptRequest {
     message: String,
+    /// Which session the turn belongs to. Without it the turn still runs, it
+    /// just leaves no snapshot behind, which is what sharing publishes.
+    #[serde(default)]
+    session_id: Option<String>,
 }
 
 struct SseEvent {
@@ -148,6 +155,7 @@ async fn process_chat_prompt(
     Json(payload): Json<PromptRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let t_state = state.clone();
+    let session_id = payload.session_id.clone();
     let (tx, rx) = mpsc::channel::<SseEvent>(32);
     let cancel_token = CancellationToken::new();
     let t_cancel = cancel_token.clone();
@@ -170,14 +178,20 @@ async fn process_chat_prompt(
             handle_pi_errors(err_str.to_owned(), &tx).await;
             return;
         }
-        tokio::select! {
+        let ended = tokio::select! {
                 _ = t_cancel.cancelled() => {
                     log::info!("Will cancel the agent process");
                     let _ = handle_graceful_exit(&mut agent.writer).await;
                     // To read the rest of stdout after aborting the current request
-                    let _ = read_from_pi(agent, &tx).await;
+                    read_from_pi(agent, &tx).await
                  },
-                _ = read_from_pi(agent, &tx) => ()
+                ended = read_from_pi(agent, &tx) => ended
+        };
+
+        // pi has reported the whole turn by now, so this is the one moment the
+        // thinking and the tool calls exist together in one place
+        if let (Some(session_id), Some(ended)) = (session_id, ended) {
+            record_turn(&session_id, ended);
         }
     });
 
@@ -205,8 +219,11 @@ async fn handle_pi_errors(err_str: String, tx: &Sender<SseEvent>) {
     let _ = tx.send(event).await.map_err(|e| log::error!("{:?}", e));
 }
 
-async fn read_from_pi(agent: &mut PiAgent, tx: &Sender<SseEvent>) {
+/// Returns the turn Pi reported, which is what a snapshot is built from.
+async fn read_from_pi(agent: &mut PiAgent, tx: &Sender<SseEvent>) -> Option<PiAgentEndEvent> {
     let mut last_event = String::from("");
+    let mut ended = None;
+
     while let Ok(Some(line)) = agent.reader.next_line().await {
         let response = if let Ok(response) = serde_json::from_str::<PiResponse>(&line) {
             response
@@ -214,7 +231,7 @@ async fn read_from_pi(agent: &mut PiAgent, tx: &Sender<SseEvent>) {
             let err_str = format!("Failed to parse pi response, response {:?}", &line);
 
             handle_pi_errors(err_str.to_owned(), tx).await;
-            return;
+            return ended;
         };
 
         let sse_event = SseEvent {
@@ -226,10 +243,65 @@ async fn read_from_pi(agent: &mut PiAgent, tx: &Sender<SseEvent>) {
 
         match response {
             PiResponse::AgentSettled => break,
+            PiResponse::AgentEnd(event) => ended = Some(event),
             _ => continue,
         }
     }
     log::info!("reading ended with last event {}", last_event);
+
+    ended
+}
+
+/// Nothing here is worth failing a turn over, the reply already reached the
+/// caller. A missing snapshot only costs the richer share.
+fn record_turn(session_id: &str, ended: PiAgentEndEvent) {
+    let model = match get_agent_start_params(DefaultProvider) {
+        Ok((model, _)) => model,
+        Err(err) => {
+            log::warn!("No model name for the snapshot: {err:?}");
+            String::new()
+        }
+    };
+
+    let mut turn = Turn {
+        api: Some(String::from("open-responses")),
+        provider: Some(String::from("tiles")),
+        model,
+        messages: ended.messages,
+    };
+
+    // pi reports the assistant's thinking and its answer as separate messages,
+    // and a snapshot reads better with the parts of one reply kept together
+    fold_assistant_messages(&mut turn);
+
+    // the connection is not Send, so it must not outlive this synchronous scope
+    let recorded = get_db_conn(&DBTYPE::CHAT)
+        .and_then(|conn| append_turn_to_snapshot(&conn, session_id, turn));
+
+    if let Err(err) = recorded {
+        log::warn!("Could not record the turn for session {session_id}: {err:?}");
+    }
+}
+
+fn fold_assistant_messages(turn: &mut Turn) {
+    let mut folded: Vec<crate::core::agent::types::PiMsgEvent> = vec![];
+
+    for message in turn.messages.drain(..) {
+        let is_assistant = matches!(message.role, tilekit::modelfile::Role::Assistant);
+
+        match folded.last_mut() {
+            Some(previous)
+                if is_assistant && matches!(previous.role, tilekit::modelfile::Role::Assistant) =>
+            {
+                let mut content: Vec<PiMsgContent> = message.content;
+                previous.content.append(&mut content);
+                previous.stop_reason = message.stop_reason;
+            }
+            _ => folded.push(message),
+        }
+    }
+
+    turn.messages = folded;
 }
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
A chat shared from the app came out flat next to the same chat shared from the REPL:

| | REPL | app |
|---|---|---|
| model | `unsloth/gemma-4-12b-it-GGUF:Q4_K_M` | `''` |
| assistant content | `['thinking', 'text']` | `['text']` |
| stopReason | `stop` | none |

## Why

The REPL builds its snapshot from the events Pi hands it, where the thinking, the tool calls and the answer arrive as separate typed parts. #207 rebuilt one from the saved chat rows instead, and those rows only ever hold the final text of a turn — the UI's `persistTurn` sends `content` and never sends `reasoning`. So the thinking was already gone before sharing saw it, and no amount of rebuilding could recover it.

## The fix

The daemon receives the same events the REPL does. `read_from_pi` was forwarding `PiResponse::AgentEnd` to the browser and dropping it on the floor. It now keeps it and writes the snapshot itself, so the data never has to survive a round trip through flat text.

That needs to know which session a turn belongs to, so **`/agent/prompt` takes an optional `session_id`**. It is optional and defaulted, so an existing caller keeps working; it just leaves no snapshot behind.

Two smaller things came with it:

- Pi reports the thinking and the answer as two separate assistant messages. A shared turn reads better with the parts of one reply kept together, so consecutive assistant messages are folded.
- Recording a turn never fails the turn. The reply has already reached the caller by then, and a missing snapshot only costs the richer share.

Rebuilding from rows stays as the fallback for sessions that predate this, including the ones already in the database.

## Testing

Verified against a real turn through a running daemon, not a fixture:

```
model: 'unsloth/gemma-4-12b-it-GGUF:Q4_K_M' | api: open-responses | provider: tiles
  role=user       types=['text']              stopReason=None
  role=assistant  types=['thinking', 'text']  stopReason=stop
    thinking: The user is asking for the result of 2+2. I need to think it through. ...
```

which matches what the REPL produces. Full suite passes apart from the pre-existing `daemon::account::tests::test_create_account` failure, which also fails on a clean canary.

Note this is written as the turn happens, so an existing session gains nothing retroactively — a new chat is needed to see it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791583619&installation_model_id=435623&pr_number=210&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F210&signature=3c9d99151bf448fcf697b1360e1a8ce7ccde00406b720ca74b0759a983e7a3e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->