### PR TITLE
The build takes the latest chat UI

### DIFF
--- a/apps/menubar/scripts/bundle-ui.sh
+++ b/apps/menubar/scripts/bundle-ui.sh
@@ -22,10 +22,20 @@ else
     git clone -q "$repo" "$ui"
   fi
 
-  # a bare sha is not a ref, so ask for it directly and fall back to everything
-  git -C "$ui" fetch -q origin "$commit" 2>/dev/null || git -C "$ui" fetch -q origin
-  git -C "$ui" checkout -q --detach "$commit"
+  if [ "$commit" = "latest" ]; then
+    # HEAD rather than a branch name, so this follows whatever the repo calls
+    # its default branch
+    git -C "$ui" fetch -q origin HEAD
+    git -C "$ui" checkout -q --detach FETCH_HEAD
+  else
+    # a bare sha is not a ref, so ask for it directly and fall back to everything
+    git -C "$ui" fetch -q origin "$commit" 2>/dev/null || git -C "$ui" fetch -q origin
+    git -C "$ui" checkout -q --detach "$commit"
+  fi
 fi
+
+# a floating build has nothing else recording which ui it carries
+echo "chat ui: $(git -C "$ui" rev-parse HEAD)"
 
 cd "$ui"
 

--- a/apps/menubar/ui.pin
+++ b/apps/menubar/ui.pin
@@ -1,4 +1,10 @@
-# The chat UI this app carries. Bump the commit to ship a newer one, the
-# build fetches exactly this and nothing else.
+# The chat UI this app carries.
+#
+# `latest` takes whatever is on the repo's default branch at build time, so UI
+# work ships without a second commit here. The build prints the commit it
+# resolved, since that is the only record of what a given package contains.
+#
+# Put a commit sha here instead to hold a build to one, for a release that has
+# to stay reproducible.
 repo=https://github.com/tilesprivacy/tiles-ui.git
-commit=9483c4832e07e20a43bfb85a259650f6625a0d6d
+commit=latest


### PR DESCRIPTION
`ui.pin` named a commit, so shipping UI work always needed a second commit here to bump it. Forgetting produced a package with new daemon endpoints and a UI that never called them, which happened twice: once before #206, and again with `session_id` where the snapshots would have stayed empty.

`ui.pin` now says `latest` and the build resolves the repo's default branch at build time.

A sha still works and still holds a build to one commit, which is what a release that has to be reproducible should use. The file says so.

## Traceability

With nothing pinned, the build log becomes the only record of which UI a package contains, so the resolved commit is printed:

```
chat ui: 8335a20a...
```

`FETCH_HEAD` rather than `origin/main`, for two reasons: it follows whatever the repo calls its default branch, and the cached remote ref in an existing checkout is unreliable. The cache on this machine still had `origin/main` at `2fb088e` while the real head was `8335a20`, because the old code only ever fetched specific commits and never updated the branch ref.

## Trade-off

This trades reproducibility for not shipping half a feature. Two builds of the same `tiles` commit can now differ. That seems the right way round while the UI and the daemon are changing together, and pinning a sha is still there for when it isn't.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791583849&installation_model_id=435623&pr_number=211&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F211&signature=f72df06ac016f1c709ac4b79985e0f102fd1d2d03054bd841c26843c4c7b3724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->