### PR TITLE
A daemon that fails to boot now says so

### DIFF
--- a/apps/menubar/src-tauri/src/boot.rs
+++ b/apps/menubar/src-tauri/src/boot.rs
@@ -4,12 +4,14 @@
 //! before it gets out of the way: make sure the daemon is running. it will spawn
 //! its own copy of us, and the single instance plugin hands over
 
+use std::fs::{File, OpenOptions};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use tauri::AppHandle;
 
-use crate::{daemon, lifeline};
+use crate::{daemon, lifeline, paths};
 
 const CLI: &str = "/usr/local/bin/tiles";
 const POLL: Duration = Duration::from_millis(300);
@@ -17,6 +19,22 @@ const GIVE_UP: Duration = Duration::from_secs(20);
 
 fn cli() -> String {
     std::env::var("TILES_CLI_BIN").unwrap_or_else(|_| CLI.to_owned())
+}
+
+/// A daemon that dies during startup is the one that most needs its words
+/// kept: it is not up to write its own logs, and health can only say "down".
+/// The daemon resolves a blank `data.path` to this same default, so a moved
+/// data folder strands only this file, not the daemon's own logs.
+fn log_file() -> Option<(PathBuf, File)> {
+    let dir = paths::default_dir()?.join("logs");
+    std::fs::create_dir_all(&dir).ok()?;
+    let path = dir.join("boot.log");
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()?;
+    Some((path, file))
 }
 
 pub fn init(app: &AppHandle) {
@@ -31,16 +49,27 @@ pub fn init(app: &AppHandle) {
             return;
         }
 
+        // both streams share one file, appends interleave the way a terminal would
+        let (log_path, out, err) = match log_file() {
+            Some((path, file)) => match file.try_clone() {
+                Ok(clone) => (Some(path), Stdio::from(file), Stdio::from(clone)),
+                Err(_) => (None, Stdio::null(), Stdio::null()),
+            },
+            None => (None, Stdio::null(), Stdio::null()),
+        };
+
         // detached, so it outlives us when the handover happens
         let spawned = Command::new(cli())
             .arg("daemon")
             .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stdout(out)
+            .stderr(err)
             .spawn();
 
         if let Err(err) = spawned {
-            eprintln!("[boot] could not start the daemon: {err}");
+            // the reason lands in the panel footer, which is the only place a
+            // person is looking when the window never appears
+            daemon::report_boot_failure(&app, format!("Could not start the daemon: {err}"));
             return;
         }
 
@@ -52,8 +81,11 @@ pub fn init(app: &AppHandle) {
             tokio::time::sleep(POLL).await;
         }
 
-        eprintln!("[boot] daemon did not come up");
-        let _ = &app;
+        let reason = match log_path {
+            Some(path) => format!("The daemon did not come up, see {}", path.display()),
+            None => "The daemon did not come up, and its log could not be written".to_owned(),
+        };
+        daemon::report_boot_failure(&app, reason);
     });
 }
 

--- a/apps/menubar/src-tauri/src/daemon.rs
+++ b/apps/menubar/src-tauri/src/daemon.rs
@@ -31,11 +31,15 @@ pub enum Health {
 
 pub struct Daemon {
     health: Mutex<Health>,
+    /// boot's account of why the daemon is not answering. the watcher can only
+    /// say "not running", so this wins as the reason until a ping succeeds
+    boot_error: Mutex<Option<String>>,
 }
 
 pub fn init(app: &AppHandle) {
     app.manage(Daemon {
         health: Mutex::new(Health::Starting),
+        boot_error: Mutex::new(None),
     });
 
     let app = app.clone();
@@ -59,6 +63,23 @@ async fn ping(client: &reqwest::Client) -> Option<String> {
 
 fn current(app: &AppHandle) -> Health {
     app.state::<Daemon>().health.lock().unwrap().clone()
+}
+
+/// boot could not start the daemon, or started it and it never answered.
+/// stdout and stderr used to vanish into /dev/null here, which made this the
+/// one failure a user could neither see nor report
+pub fn report_boot_failure(app: &AppHandle, reason: String) {
+    eprintln!("[boot] {reason}");
+    *app.state::<Daemon>().boot_error.lock().unwrap() = Some(reason.clone());
+    set(app, Health::Down { reason });
+}
+
+fn boot_error(app: &AppHandle) -> Option<String> {
+    app.state::<Daemon>().boot_error.lock().unwrap().clone()
+}
+
+fn clear_boot_error(app: &AppHandle) {
+    *app.state::<Daemon>().boot_error.lock().unwrap() = None;
 }
 
 /// emits on change only, the watcher polls far more often than state moves
@@ -96,6 +117,8 @@ async fn watch(app: AppHandle) {
 
         match ping(&client).await {
             Some(version) => {
+                // it answered after all, whatever boot saw is history
+                clear_boot_error(&app);
                 set(&app, Health::Up { version });
                 inference::poll(&app, &client).await;
                 account::poll(&app, &client).await;
@@ -103,12 +126,8 @@ async fn watch(app: AppHandle) {
                 remote::poll(&app, &client).await;
             }
             None => {
-                set(
-                    &app,
-                    Health::Down {
-                        reason: "not running".into(),
-                    },
-                );
+                let reason = boot_error(&app).unwrap_or_else(|| "not running".into());
+                set(&app, Health::Down { reason });
                 inference::unknown(&app);
                 account::unknown(&app);
                 atproto::unknown(&app);

--- a/apps/menubar/src-tauri/src/paths.rs
+++ b/apps/menubar/src-tauri/src/paths.rs
@@ -10,7 +10,7 @@ use tauri_nspanel::objc2_foundation::{NSString, NSURL};
 /// `data.path` is blank until the user moves it, and the daemon resolves that
 /// blank against its own dirs without publishing the result anywhere. this is
 /// the same rule for a released daemon, `$XDG_DATA_HOME` or `~/.local/share`
-fn default_dir() -> Option<PathBuf> {
+pub fn default_dir() -> Option<PathBuf> {
     let base = match std::env::var_os("XDG_DATA_HOME") {
         Some(dir) => PathBuf::from(dir),
         None => std::env::home_dir()?.join(".local/share"),


### PR DESCRIPTION
A canary user reported: opening Tiles.app shows the menu bar, but the daemon never starts and no chat window appears. Nothing on their machine says why, and that silence is this bug.

`boot.rs` spawned the daemon with stdout and stderr on `/dev/null`. A daemon that dies during startup (e.g. keychain unavailable, which is startup-fatal via the device account read) therefore vanished without a trace: too dead to write its own logs, and the app discarded the only copy of its last words.

## Changes

- The spawned daemon's output goes to `logs/boot.log` under the default data dir (`$XDG_DATA_HOME`/`~/.local/share` + `tiles/data`), the same blank-`data.path` rule the daemon itself resolves. If the log file cannot be opened, the spawn still proceeds with null streams rather than blocking startup on logging.
- A failed spawn, or a daemon that never answers within the 20s deadline, is reported into the health state with a specific reason (including the log path), so the panel footer shows it instead of the generic "not running". The watcher keeps that reason on subsequent polls and clears it the moment a ping succeeds.
- `paths::default_dir()` becomes `pub` for boot's use.

## Verification

- `cargo fmt`, `cargo clippy --all-targets` clean, 29 crate tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791631456&installation_model_id=435623&pr_number=213&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F213&signature=fb49120c06f5b37e318efb9512fcb3c72ce8dd9c5f1802738e77a5ef6f6accfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->