### PR TITLE
Pi follows the session the prompt belongs to

### DIFF
--- a/tiles/src/core/chats.rs
+++ b/tiles/src/core/chats.rs
@@ -111,6 +111,35 @@ pub fn append_turn_to_snapshot(conn: &Connection, session_id: &str, turn: Turn) 
     Ok(())
 }
 
+/// The stored turns of a session, formatted to hand Pi as context when its one
+/// conversation is switched onto this session.
+///
+/// The UI saves the user's prompt before it sends it, so the newest user row
+/// usually is the prompt itself; repeating it as history would make Pi read
+/// the question twice, so a trailing row matching `current_prompt` is skipped.
+/// None when there is nothing left to replay, which is what a fresh session
+/// switched to for its first prompt looks like.
+pub fn history_for_resume(chats: &[Chats], current_prompt: &str) -> Option<String> {
+    let mut rows = chats;
+    if let Some((last, rest)) = rows.split_last()
+        && last.role == Role::User
+        && last.content == current_prompt
+    {
+        rows = rest;
+    }
+
+    if rows.is_empty() {
+        return None;
+    }
+
+    let lines: Vec<String> = rows
+        .iter()
+        .map(|chat| format!("{}: {}", Into::<String>::into(chat.role), chat.content))
+        .collect();
+
+    Some(lines.join("\n"))
+}
+
 /// Rebuilds a snapshot from the stored rows.
 ///
 /// The REPL keeps a snapshot as it goes, built from the events Pi hands it. The
@@ -551,6 +580,48 @@ pub mod tests {
         repl::ChatResponse,
         utils::{get_unix_time_now, test_logger},
     };
+
+    fn history_row(role: Role, content: &str) -> super::Chats {
+        super::Chats {
+            id: Uuid::now_v7().to_string(),
+            content: content.to_owned(),
+            response_id: None,
+            role,
+            user_id: "u".to_owned(),
+            context_id: None,
+            created_at: 1,
+            updated_at: 1,
+            row_counter: 1,
+            session_id: "s".to_owned(),
+            model_name: String::new(),
+        }
+    }
+
+    #[test]
+    fn resume_history_carries_roles_and_drops_the_prompt_itself() {
+        use super::history_for_resume;
+
+        let chats = vec![
+            history_row(Role::User, "first question"),
+            history_row(Role::Assistant, "first answer"),
+            history_row(Role::User, "new question"),
+        ];
+
+        // the UI saves the prompt before sending it, so the trailing copy goes
+        let history = history_for_resume(&chats, "new question").unwrap();
+        assert!(history.contains("first question"));
+        assert!(history.contains("first answer"));
+        assert!(!history.contains("new question"));
+
+        // an unrelated trailing user row is real history and stays
+        let history = history_for_resume(&chats, "something else").unwrap();
+        assert!(history.contains("new question"));
+
+        // a session with nothing but the prompt has nothing to replay
+        let only_prompt = vec![history_row(Role::User, "new question")];
+        assert!(history_for_resume(&only_prompt, "new question").is_none());
+        assert!(history_for_resume(&[], "anything").is_none());
+    }
 
     /// A session started from the app has no stored snapshot, so sharing one
     /// depends on this rebuilding the turns from the rows.

--- a/tiles/src/daemon/agent.rs
+++ b/tiles/src/daemon/agent.rs
@@ -5,7 +5,7 @@ use crate::{
         pi::{self, PiAgent, handle_graceful_exit},
         types::{PiAgentEndEvent, PiMsgContent, PiResponse},
     },
-    core::chats::append_turn_to_snapshot,
+    core::chats::{append_turn_to_snapshot, fetch_chats_by_session_id, history_for_resume},
     core::plugin::{self, Invocation},
     core::storage::db::{DBTYPE, get_db_conn},
     daemon::{ApiResponse, AppError, AppState},
@@ -131,6 +131,8 @@ async fn start_agent(State(state): State<Arc<AppState>>) -> Result<impl IntoResp
         let pi_agent = pi::new(&modelname, &system_prompt, PY_PORT)
             .map_err(|e| AppError::InternalServerError(e.to_string()))?;
         *agent = Some(pi_agent);
+        // a fresh Pi holds a conversation no session owns yet
+        *state.active_session.lock().await = None;
         Ok(ApiResponse::success(json!({"message": "started agent"})))
     }
 }
@@ -168,6 +170,8 @@ async fn reload_agent(State(state): State<Arc<AppState>>) -> Result<impl IntoRes
     let pi_agent = pi::new(&modelname, &system_prompt, PY_PORT)
         .map_err(|e| AppError::InternalServerError(e.to_string()))?;
     *agent = Some(pi_agent);
+    // a fresh Pi holds a conversation no session owns yet
+    *state.active_session.lock().await = None;
 
     Ok(ApiResponse::success(json!({"message": "reloaded agent"})))
 }
@@ -274,6 +278,36 @@ async fn process_chat_prompt(
                     )
                     .await;
                     return;
+                }
+            }
+        }
+
+        // Pi holds one conversation, and nothing tells it when the UI switches
+        // tabs. A prompt for a session other than the one Pi is on would be
+        // answered with the wrong context, so reset Pi and replay the stored
+        // turns first, the way the REPL resumes a session.
+        if let Some(sid) = &session_id {
+            let mut active = t_state.active_session.lock().await;
+            if active.as_deref() != Some(sid.as_str()) {
+                match agent.reader.create_new_session(&mut agent.writer).await {
+                    Ok(_) => {
+                        *active = Some(sid.clone());
+                        let history = get_db_conn(&DBTYPE::CHAT)
+                            .ok()
+                            .and_then(|conn| fetch_chats_by_session_id(&conn, sid).ok())
+                            .and_then(|delta| history_for_resume(&delta.chats, &message));
+                        if let Some(history) = history {
+                            message = format!(
+                                "user_chat_history:\n{}.\nUse the history as context.\n[Followup question] - {}",
+                                history, message
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        // the turn still runs; wrong context beats no answer,
+                        // and the next prompt will try the switch again
+                        log::warn!("Could not switch Pi to session {sid}: {err}");
+                    }
                 }
             }
         }

--- a/tiles/src/daemon/mod.rs
+++ b/tiles/src/daemon/mod.rs
@@ -71,6 +71,11 @@ pub struct AppState {
     pub remote_running: Mutex<bool>,
     pub remote_shutdown_sender: Mutex<Option<oneshot::Sender<bool>>>,
     pub agent: AsyncMutex<Option<PiAgent>>,
+    /// Which session Pi's one live conversation belongs to. Pi holds a single
+    /// conversation, and the UI switches sessions freely, so a prompt for a
+    /// different session must reset Pi and replay that session's history first
+    /// or it would be answered with another tab's context.
+    pub active_session: AsyncMutex<Option<String>>,
     pub ui: Arc<Ui>,
 }
 
@@ -85,6 +90,7 @@ impl AppState {
             remote_shutdown_sender: Mutex::new(None),
             remote_running: Mutex::new(false),
             agent: None.into(),
+            active_session: None.into(),
             ui: Ui::new(),
         }
     }
@@ -292,6 +298,7 @@ pub async fn start_server(port: Option<u32>, with_ui: bool, show_ui: bool) -> Re
         remote_ticket: Mutex::new(None),
         remote_shutdown_sender: Mutex::new(None),
         remote_running: Mutex::new(false),
+        active_session: None.into(),
         agent: None.into(),
         ui: ui.clone(),
     };

--- a/tiles/src/daemon/session.rs
+++ b/tiles/src/daemon/session.rs
@@ -81,6 +81,9 @@ async fn do_create_session(
             .await
             .map_err(|e| AppError::CannotProcess(e.to_string()))?;
 
+        // Pi's one conversation now belongs to this session and no other
+        *state.active_session.lock().await = Some(agent_state.session_id.clone());
+
         let session_data = Session {
             id: agent_state.session_id,
         };
@@ -95,13 +98,16 @@ async fn do_create_session(
             "No agent instance available, start one first".to_string(),
         ))?;
 
-        let state = agent
+        let pi_state = agent
             .reader
             .get_pi_state(&mut agent.writer)
             .await
             .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+        *state.active_session.lock().await = Some(pi_state.session_id.clone());
+
         Ok(ApiResponse::success(Session {
-            id: state.session_id,
+            id: pi_state.session_id,
         }))
     }
 }


### PR DESCRIPTION
Cross-session context bleed: Pi holds a single conversation, the UI switches sessions freely, and nothing reconciled the two. Creating a new chat sent Pi `new_session`; switching back to an older tab sent nothing, so the next prompt there was answered with the other tab's context and saved under the old session id.

## Changes

- `AppState.active_session` tracks which session Pi's conversation currently belongs to. Set on `session/new` (both branches), cleared when Pi is started or reloaded fresh.
- The prompt handler compares the request's `session_id` against it: on mismatch it sends Pi `new_session` and replays the session's stored rows as `user_chat_history` context — the same resume shape the REPL uses, with two improvements: rows carry their roles, and the trailing user row matching the prompt itself is dropped (the UI saves the prompt before sending it, so replaying it would make Pi read the question twice).
- A failed switch logs and lets the turn run on the current context — wrong context beats no answer, and the next prompt retries the switch.

## Notes

- Replay is row-based, so a resumed session's context has final text only (same fidelity the REPL resume has today). Feeding the snapshot's full turns instead is a possible follow-up.
- `@name` resolution composes: the mention is resolved first, then the resolved message is wrapped with history, matching REPL ordering.

## Verification

- New unit test `resume_history_carries_roles_and_drops_the_prompt_itself`.
- fmt/clippy clean; 163 tests pass, the 1 failure is the pre-existing `test_create_account`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791641698&installation_model_id=435623&pr_number=216&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F216&signature=9559a0c2a3f1e68b31fd24e73c53cea8eab42cbd57495ae38cb2240c9df7fd91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->