### PR TITLE
new_session survives the adapter announcing itself

### DIFF
--- a/tiles/src/core/agent/pi.rs
+++ b/tiles/src/core/agent/pi.rs
@@ -193,6 +193,25 @@ impl PiReader {
             .unwrap_or_default()
             .to_owned();
 
+        self.request_optional(writer, payload)
+            .await?
+            .ok_or_else(|| anyhow!("Pi returned no data for {}", request_type))
+    }
+
+    /// Like `request`, for commands whose response carries no data. An ack is
+    /// the whole answer to `new_session`, and demanding data of it would turn
+    /// every success into an error.
+    async fn request_optional(
+        &mut self,
+        writer: &mut PiWriter,
+        payload: Value,
+    ) -> Result<Option<Value>> {
+        let request_type = payload
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_owned();
+
         writer
             .send_to_pi(payload)
             .await
@@ -205,9 +224,10 @@ impl PiReader {
             };
             match serde_json::from_str::<PiResponse>(&line) {
                 Ok(PiResponse::Response(msg)) => {
-                    return msg
-                        .data
-                        .ok_or_else(|| anyhow!("Pi returned no data for {}", request_type));
+                    if !msg.success {
+                        return Err(anyhow!("Pi answered {} with a failure", request_type));
+                    }
+                    return Ok(msg.data);
                 }
                 _ => {
                     info!(
@@ -246,26 +266,18 @@ impl PiReader {
     }
 
     /// Creates a new Pi session
+    /// Resets Pi's one conversation.
+    ///
+    /// Goes through the event-skipping request loop: extensions announce
+    /// themselves on the same stream, and the naive single read this used to
+    /// do would take an `extension_ui_request` for the answer, fail the call,
+    /// and leave the real response behind to desync the next reader.
     pub async fn create_new_session(&mut self, writer: &mut PiWriter) -> Result<GetStateData> {
-        let cmd_payload = json!({
-            "type": "new_session",
-        });
+        self.request_optional(writer, json!({ "type": "new_session" }))
+            .await
+            .context("Creating new session failed")?;
 
-        writer.send_to_pi(cmd_payload).await?;
-
-        if let Some(line) = self.lines.next_line().await? {
-            let response: PiResponse = serde_json::from_str(&line)?;
-            if let PiResponse::Response(msg) = response
-                && msg.success
-            {
-                let state = self.get_pi_state(writer).await?;
-                Ok(state)
-            } else {
-                Err(anyhow!("Creating new session failed"))
-            }
-        } else {
-            Err(anyhow!("Failed to fetch session_id from Pi"))
-        }
+        self.get_pi_state(writer).await
     }
 }
 


### PR DESCRIPTION
Live debugging of "the session-switch fix did nothing": it was firing and failing every time.

## Root cause

`PiReader::create_new_session` read exactly one line and required it to be its own success response. The bundled MCP adapter emits `extension_ui_request` events (`setStatus: "MCP: 1 server enabled"`) on the same stream, including right at session reset — so with the adapter loaded (always, since #212) the single read got an event, the call failed, and:

- `/session/new` answered 422,
- the prompt path in #216 logged "Could not switch Pi to session" and ran the prompt on the **wrong** session anyway — the exact bug #216 was meant to fix,
- the unconsumed `new_session` response stayed in the stream and desynced the next reader (observed: duplicate `response` events in a later prompt stream, and one fully wedged daemon holding the agent lock).

The spike added the event-skipping `request()` loop for `get_state`/`get_commands` for precisely this reason; `create_new_session` was the one reader never converted.

## Changes

- `request()` split into `request_optional()` (same bounded skip loop, returns `Option<Value>`, surfaces `success: false` as an error) with `request()` layered on top demanding data.
- `create_new_session` goes through `request_optional` — an ack is the whole answer to `new_session` — then reads state via the existing `get_pi_state`.

## Verified live

Ran the release build as the daemon against the installed layout: seeded session A with "favorite fruit is pineapple", session B with mango, then prompted A while Pi was parked on B. Answer: **"Pineapple"**, the log shows the adapter's `setStatus` events being skipped during `new_session`, and the stream carries exactly one `response` event (previously two — the leak).

fmt/clippy clean; 163 tests pass, 1 pre-existing failure (`test_create_account`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791643325&installation_model_id=435623&pr_number=217&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F217&signature=b0a33780d0414ac0889d939590f8e2fac9c17a82650643c27a625b339b54dd4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->