### PR TITLE
fix: improve menubar power handling and session reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7999,6 +7999,7 @@ dependencies = [
 name = "tiles-menubar"
 version = "0.1.0"
 dependencies = [
+ "core-foundation 0.10.1",
  "data-encoding",
  "reqwest 0.12.28",
  "serde",

--- a/apps/menubar/src-tauri/Cargo.toml
+++ b/apps/menubar/src-tauri/Cargo.toml
@@ -22,4 +22,4 @@ data-encoding = "2"
 tokio = { version = "1", features = ["time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-
+core-foundation = "0.10"

--- a/apps/menubar/src-tauri/src/awake.rs
+++ b/apps/menubar/src-tauri/src/awake.rs
@@ -4,6 +4,11 @@ use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use core_foundation::array::{CFArray, CFArrayRef};
+use core_foundation::base::{CFType, CFTypeRef, TCFType};
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
+use core_foundation::number::CFNumber;
+use core_foundation::string::{CFString, CFStringRef};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -13,17 +18,90 @@ pub const STATE_EVENT: &str = "awake://state";
 /// see coming, which a Drop impl cannot promise
 const CAFFEINATE: &str = "/usr/bin/caffeinate";
 
-/// -2.0, an external source with no battery to run down. a desktop reads this
-/// too, which is the right answer for a machine that is always plugged in
-const UNLIMITED: f64 = -2.0;
+const MINIMUM_BATTERY_PERCENT: u8 = 10;
 
 #[link(name = "IOKit", kind = "framework")]
 unsafe extern "C" {
-    fn IOPSGetTimeRemainingEstimate() -> f64;
+    fn IOPSCopyPowerSourcesInfo() -> CFTypeRef;
+    fn IOPSCopyPowerSourcesList(blob: CFTypeRef) -> CFArrayRef;
+    fn IOPSGetPowerSourceDescription(blob: CFTypeRef, source: CFTypeRef) -> CFDictionaryRef;
+    fn IOPSGetProvidingPowerSourceType(blob: CFTypeRef) -> CFStringRef;
 }
 
-fn on_ac() -> bool {
-    unsafe { IOPSGetTimeRemainingEstimate() == UNLIMITED }
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DevicePower {
+    pub plugged_in: bool,
+    pub battery_percent: Option<u8>,
+}
+
+impl DevicePower {
+    fn allows_stay_awake(self) -> bool {
+        self.plugged_in
+            || self
+                .battery_percent
+                .is_some_and(|percent| percent > MINIMUM_BATTERY_PERCENT)
+    }
+}
+
+/// IOKit owns the source descriptions; the snapshot and list are copy-rule
+/// values wrapped here so every early return releases them.
+fn device_power() -> DevicePower {
+    unsafe {
+        let snapshot_ref = IOPSCopyPowerSourcesInfo();
+        if snapshot_ref.is_null() {
+            return DevicePower::default();
+        }
+        let snapshot = CFType::wrap_under_create_rule(snapshot_ref);
+
+        let source_ref = IOPSGetProvidingPowerSourceType(snapshot.as_CFTypeRef());
+        let plugged_in = !source_ref.is_null()
+            && CFString::wrap_under_get_rule(source_ref).to_string() == "AC Power";
+
+        let list_ref = IOPSCopyPowerSourcesList(snapshot.as_CFTypeRef());
+        if list_ref.is_null() {
+            return DevicePower {
+                plugged_in,
+                battery_percent: None,
+            };
+        }
+        let sources: CFArray<CFType> = CFArray::wrap_under_create_rule(list_ref);
+        let type_key = CFString::new("Type");
+        let current_key = CFString::new("Current Capacity");
+        let maximum_key = CFString::new("Max Capacity");
+
+        let battery_percent = sources.iter().find_map(|source| {
+            let description_ref =
+                IOPSGetPowerSourceDescription(snapshot.as_CFTypeRef(), source.as_CFTypeRef());
+            if description_ref.is_null() {
+                return None;
+            }
+            let description: CFDictionary<CFString, CFType> =
+                CFDictionary::wrap_under_get_rule(description_ref);
+
+            let source_type = description
+                .find(&type_key)
+                .and_then(|value| value.downcast::<CFString>())?;
+            if source_type.to_string() != "InternalBattery" {
+                return None;
+            }
+
+            let number = |key: &CFString| {
+                description
+                    .find(key)
+                    .and_then(|value| value.downcast::<CFNumber>())
+                    .and_then(|value| value.to_i32())
+            };
+            let current = number(&current_key)?;
+            let maximum = number(&maximum_key)?;
+            (maximum > 0).then(|| (current.clamp(0, maximum) * 100 / maximum) as u8)
+        });
+
+        DevicePower {
+            plugged_in,
+            battery_percent,
+        }
+    }
 }
 
 fn now_ms() -> u64 {
@@ -47,8 +125,8 @@ pub struct State {
     /// the reading in ms while paused, which has no wall clock to sit against.
     /// already whole seconds, so it does not step when the clock stops
     pub frozen: Option<u64>,
-    /// on battery none of it can be taken at all, and the plate says so
-    pub ac: bool,
+    /// the current battery and charger state used to gate new sessions
+    pub power: DevicePower,
 }
 
 const IDLE: State = State {
@@ -57,7 +135,10 @@ const IDLE: State = State {
     since: None,
     until: None,
     frozen: None,
-    ac: false,
+    power: DevicePower {
+        plugged_in: false,
+        battery_percent: None,
+    },
 };
 
 /// a run of the clock, which pausing banks and resuming starts again
@@ -150,9 +231,9 @@ fn set(app: &AppHandle, next: State) {
 
 /// what the panel draws, off the session rather than off the clock, so a tick
 /// that moved nothing emits nothing
-fn describe(held: &Held, ac: bool) -> State {
+fn describe(held: &Held, power: DevicePower) -> State {
     let Some(session) = held.session else {
-        return State { ac, ..IDLE };
+        return State { power, ..IDLE };
     };
 
     if session.running() {
@@ -160,7 +241,7 @@ fn describe(held: &Held, ac: bool) -> State {
             active: held.child.is_some(),
             since: session.since(),
             until: session.until(),
-            ac,
+            power,
             ..IDLE
         };
     }
@@ -168,7 +249,7 @@ fn describe(held: &Held, ac: bool) -> State {
     State {
         paused: true,
         frozen: Some(session.frozen()),
-        ac,
+        power,
         ..IDLE
     }
 }
@@ -176,7 +257,7 @@ fn describe(held: &Held, ac: bool) -> State {
 /// the only place the child is started or killed, so the assertion and what the
 /// panel was told can never disagree
 fn reconcile(app: &AppHandle) {
-    let ac = on_ac();
+    let power = device_power();
     let now = now_ms();
     let awake = app.state::<Awake>();
     let mut held = awake.held.lock().unwrap();
@@ -190,9 +271,9 @@ fn reconcile(app: &AppHandle) {
         held.session = None;
     }
 
-    // the mains going away ends the session rather than holding it, so the
-    // cable coming back does not relight the plate on its own
-    if !ac {
+    // dropping to the protected battery level ends the session rather than
+    // relighting it automatically when power becomes available again
+    if !power.allows_stay_awake() {
         held.session = None;
     }
 
@@ -235,14 +316,14 @@ fn reconcile(app: &AppHandle) {
         _ => {}
     }
 
-    let next = describe(&held, ac);
+    let next = describe(&held, power);
     drop(held);
 
     set(app, next);
 }
 
-/// one supervisor pass, outside the health branch. the mains and the deadline
-/// are not the daemon's business, and a session outlives it going away
+/// one supervisor pass, outside the health branch. power and the deadline are
+/// not the daemon's business, and a session outlives it going away
 pub fn tick(app: &AppHandle) {
     reconcile(app);
 }
@@ -255,7 +336,11 @@ pub fn awake_state(app: AppHandle) -> State {
 /// `seconds` of `None` is the open ended one the menu offers last. a pick while
 /// one is already going replaces it rather than stacking on it
 #[tauri::command]
-pub fn awake_start(app: AppHandle, seconds: Option<u64>) {
+pub fn awake_start(app: AppHandle, seconds: Option<u64>) -> Result<(), String> {
+    if !device_power().allows_stay_awake() {
+        return Err("Connect a charger or charge above 10% to use Stay Awake".into());
+    }
+
     {
         let awake = app.state::<Awake>();
         let mut held = awake.held.lock().unwrap();
@@ -266,6 +351,7 @@ pub fn awake_start(app: AppHandle, seconds: Option<u64>) {
         });
     }
     reconcile(&app);
+    Ok(())
 }
 
 #[tauri::command]
@@ -295,7 +381,11 @@ pub fn awake_pause(app: AppHandle) {
 }
 
 #[tauri::command]
-pub fn awake_resume(app: AppHandle) {
+pub fn awake_resume(app: AppHandle) -> Result<(), String> {
+    if !device_power().allows_stay_awake() {
+        return Err("Connect a charger or charge above 10% to resume Stay Awake".into());
+    }
+
     {
         let awake = app.state::<Awake>();
         let mut held = awake.held.lock().unwrap();
@@ -306,11 +396,12 @@ pub fn awake_resume(app: AppHandle) {
         }
     }
     reconcile(&app);
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Session;
+    use super::{DevicePower, Session};
 
     const NOW: u64 = 1_700_000_000_000;
 
@@ -320,6 +411,32 @@ mod tests {
             elapsed: 0,
             started: Some(NOW),
         }
+    }
+
+    #[test]
+    fn stay_awake_needs_power_or_more_than_ten_percent() {
+        assert!(
+            DevicePower {
+                plugged_in: true,
+                battery_percent: Some(1),
+            }
+            .allows_stay_awake()
+        );
+        assert!(
+            DevicePower {
+                plugged_in: false,
+                battery_percent: Some(11),
+            }
+            .allows_stay_awake()
+        );
+        assert!(
+            !DevicePower {
+                plugged_in: false,
+                battery_percent: Some(10),
+            }
+            .allows_stay_awake()
+        );
+        assert!(!DevicePower::default().allows_stay_awake());
     }
 
     /// the run in progress counts, and the banked part counts with it

--- a/apps/menubar/src/lib/AwakeMenu.svelte
+++ b/apps/menubar/src/lib/AwakeMenu.svelte
@@ -2,6 +2,9 @@
   interface Props {
     /** a session exists, running or held */
     session: "none" | "running" | "paused";
+    /** new or resumed sessions need mains or enough battery */
+    available: boolean;
+    note: string;
     /** `null` is the open ended one */
     onpick: (seconds: number | null) => void;
     onpause: () => void;
@@ -9,7 +12,7 @@
     onstop: () => void;
   }
 
-  let { session, onpick, onpause, onresume, onstop }: Props = $props();
+  let { session, available, note, onpick, onpause, onresume, onstop }: Props = $props();
 
   const DURATIONS: { label: string; seconds: number | null }[] = [
     { label: "15 minutes", seconds: 15 * 60 },
@@ -22,6 +25,9 @@
 </script>
 
 <div class="menu" role="menu">
+  <p class="menu__note" data-alert={!available}>{note}</p>
+  <div class="menu__rule"></div>
+
   {#if session !== "none"}
     <!-- what to do with the session already going, above the lengths that
          would replace it -->
@@ -30,7 +36,12 @@
         Pause
       </button>
     {:else}
-      <button class="menu__item menu__item--lead" role="menuitem" onclick={onresume}>
+      <button
+        class="menu__item menu__item--lead"
+        role="menuitem"
+        disabled={!available}
+        onclick={onresume}
+      >
         Resume
       </button>
     {/if}
@@ -41,7 +52,12 @@
   {/if}
 
   {#each DURATIONS as duration (duration.label)}
-    <button class="menu__item" role="menuitem" onclick={() => onpick(duration.seconds)}>
+    <button
+      class="menu__item"
+      role="menuitem"
+      disabled={!available}
+      onclick={() => onpick(duration.seconds)}
+    >
       {duration.label}
     </button>
   {/each}
@@ -92,6 +108,25 @@
 
   .menu__item:hover {
     color: var(--signal);
+  }
+
+  .menu__item:disabled {
+    color: var(--slate);
+    opacity: 0.45;
+  }
+
+  .menu__note {
+    width: 190px;
+    margin: 0;
+    padding: 7px var(--pad-x);
+    color: var(--slate);
+    font-family: var(--font-ui);
+    font-size: var(--fs-meta);
+    line-height: 1.35;
+  }
+
+  .menu__note[data-alert="true"] {
+    color: var(--alert);
   }
 
   .menu__rule {

--- a/apps/menubar/src/lib/Footer.svelte
+++ b/apps/menubar/src/lib/Footer.svelte
@@ -40,6 +40,17 @@
   const session = $derived.by<"none" | "running" | "paused">(() =>
     awake.value.paused ? "paused" : awake.value.active ? "running" : "none",
   );
+  const powerAllowed = $derived(
+    awake.value.power.pluggedIn ||
+      (awake.value.power.batteryPercent !== null && awake.value.power.batteryPercent > 10),
+  );
+  const powerCopy = $derived.by(() => {
+    const percent = awake.value.power.batteryPercent;
+    if (!powerAllowed && percent !== null) {
+      return `${percent}% battery · Connect a charger to enable`;
+    }
+    return "Available when plugged in or battery is above 10%";
+  });
 
   // a session with an end counts down to it, one without counts up from where
   // it started, and a held one reads whatever it was banked at
@@ -55,6 +66,7 @@
 
   function pick(seconds: number | null) {
     menu = false;
+    if (!powerAllowed) return;
     act("awake_start", { seconds });
   }
 
@@ -89,6 +101,8 @@
       ></button>
       <AwakeMenu
         {session}
+        available={powerAllowed}
+        note={powerCopy}
         onpick={pick}
         onpause={() => run("awake_pause")}
         onresume={() => run("awake_resume")}
@@ -99,11 +113,10 @@
     <button
       class="footer__cup"
       data-state={session}
-      disabled={!awake.value.ac}
       aria-label="Keep this Mac awake"
       aria-haspopup="menu"
       aria-expanded={menu}
-      title={awake.value.ac ? "Keep this Mac awake" : "Keeping awake needs mains power"}
+      title={powerAllowed ? "Keep this Mac awake" : powerCopy}
       onclick={() => (menu = !menu)}
     >
       <!-- steam is the run, so a held session has none -->
@@ -258,13 +271,6 @@
      still accounts for a session that exists, it is just not running */
   .footer__cup[data-state="paused"] {
     color: var(--signal);
-  }
-
-  /* the assertion is only good on mains, so off them this is not a control */
-  .footer__cup:disabled {
-    background: var(--steel);
-    color: var(--slate);
-    opacity: 0.5;
   }
 
   .footer__quit:hover {

--- a/apps/menubar/src/lib/HandleField.svelte
+++ b/apps/menubar/src/lib/HandleField.svelte
@@ -65,7 +65,7 @@
       autocomplete="off"
       autocorrect="off"
       disabled={pending}
-      aria-label="Atproto handle"
+      aria-label="Atmosphere account handle"
       onkeydown={key}
     />
   </span>

--- a/apps/menubar/src/state.svelte.ts
+++ b/apps/menubar/src/state.svelte.ts
@@ -50,8 +50,10 @@ export type Awake = {
   since: number | null;
   until: number | null;
   frozen: number | null;
-  ac: boolean;
+  power: DevicePower;
 };
+
+export type DevicePower = { pluggedIn: boolean; batteryPercent: number | null };
 
 export type Remote =
   | { state: "unknown" }
@@ -67,7 +69,14 @@ export const atproto = $state<{ value: Atproto }>({ value: { state: "unknown" } 
 export const sessions = $state<{ value: Sessions }>({ value: { state: "unknown" } });
 export const remote = $state<{ value: Remote }>({ value: { state: "unknown" } });
 export const awake = $state<{ value: Awake }>({
-  value: { active: false, paused: false, since: null, until: null, frozen: null, ac: false },
+  value: {
+    active: false,
+    paused: false,
+    since: null,
+    until: null,
+    frozen: null,
+    power: { pluggedIn: false, batteryPercent: null },
+  },
 });
 
 /**

--- a/apps/menubar/src/views/AccountView.svelte
+++ b/apps/menubar/src/views/AccountView.svelte
@@ -53,7 +53,11 @@
     {/snippet}
   </Row>
   <!-- the sub said what the name was, this says what the account is -->
-  <p class="note">This Tiles account is generated and saved locally</p>
+  <p class="note">
+    Your Tiles Account is generated and secured on this device. It is ready for peer-to-peer sync,
+    remote inference, and other local-first features, using DIDs and UCANs for zero-trust
+    authentication and authorization.
+  </p>
 </Zone>
 
 <Zone label="Decentralized ID">

--- a/apps/menubar/src/views/AtmosphereView.svelte
+++ b/apps/menubar/src/views/AtmosphereView.svelte
@@ -52,8 +52,11 @@
       <Avatar nickname={name ?? session?.handle ?? "?"} src={session?.avatar} size={26} />
     {/snippet}
   </Row>
-  <!-- the sub said what the name was, this says where the account is -->
-  <p class="note">This account lives on the server below, and Tiles reads it there directly</p>
+  <!-- the sub said what the name was, this says what the account adds -->
+  <p class="note">
+    Your Atmosphere Account is connected and ready to share conversations through your AT Protocol
+    PDS.
+  </p>
 </Zone>
 
 <Zone label="Handle">

--- a/apps/menubar/src/views/RootView.svelte
+++ b/apps/menubar/src/views/RootView.svelte
@@ -241,7 +241,7 @@
 <Masthead {mode} {on} pending={busy} disabled={health.value.state !== "up"} ontoggle={toggle} />
 
 <Zone label="Accounts">
-  <h3 class="account">Tiles</h3>
+  <h3 class="account">Tiles Account</h3>
   <Row
     size="large"
     title={identity.title}
@@ -258,7 +258,7 @@
     {/snippet}
   </Row>
 
-  <h3 class="account">Atmosphere</h3>
+  <h3 class="account">Atmosphere Account</h3>
   <Row
     size="large"
     title={atmosphere.title}

--- a/tiles/src/core/agent/pi.rs
+++ b/tiles/src/core/agent/pi.rs
@@ -1,5 +1,5 @@
 //! Module that deals with Pi
-use crate::core::agent::types::{Commands, GetStateData, PiResponse};
+use crate::core::agent::types::{CommandType, Commands, GetStateData, PiResponse};
 use crate::core::plugin::{
     installed_extension_entrypoints, installed_skill_dirs, prune_copied_plugin_skills,
 };
@@ -192,7 +192,6 @@ impl PiReader {
             .and_then(|value| value.as_str())
             .unwrap_or_default()
             .to_owned();
-
         self.request_optional(writer, payload)
             .await?
             .ok_or_else(|| anyhow!("Pi returned no data for {}", request_type))
@@ -211,6 +210,9 @@ impl PiReader {
             .and_then(|value| value.as_str())
             .unwrap_or_default()
             .to_owned();
+        let expected_command: CommandType =
+            serde_json::from_value(Value::String(request_type.clone()))
+                .context("Unsupported Pi request type")?;
 
         writer
             .send_to_pi(payload)
@@ -223,7 +225,7 @@ impl PiReader {
                 return Err(anyhow!("Pi closed the connection during {}", request_type));
             };
             match serde_json::from_str::<PiResponse>(&line) {
-                Ok(PiResponse::Response(msg)) => {
+                Ok(PiResponse::Response(msg)) if msg.command == expected_command => {
                     if !msg.success {
                         return Err(anyhow!("Pi answered {} with a failure", request_type));
                     }

--- a/tiles/src/core/agent/types.rs
+++ b/tiles/src/core/agent/types.rs
@@ -254,7 +254,7 @@ pub struct PiResponseMessage {
     pub success: bool,
     pub data: Option<Value>,
 }
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum CommandType {
     #[serde(rename = "status")]
     Status,
@@ -274,6 +274,10 @@ pub enum CommandType {
     Skills,
     #[serde(rename = "get_commands")]
     GetCommands,
+    #[serde(rename = "get_state")]
+    GetState,
+    #[serde(rename = "new_session")]
+    NewSession,
     /// Pi acks every `prompt` with this.
     #[serde(rename = "prompt")]
     Prompt,

--- a/tiles/src/core/server.rs
+++ b/tiles/src/core/server.rs
@@ -25,17 +25,19 @@ pub async fn start_server_daemon() -> Result<String> {
 
     let config_dir = DefaultProvider.get_config_dir()?;
     let data_dir = DefaultProvider.get_data_dir()?;
-    let mut server_dir = DefaultProvider.get_lib_dir()?;
+    let server_dir = DefaultProvider.get_lib_dir()?;
     let pid_file = config_dir.join("server.pid");
-    server_dir = server_dir.join("server");
     let stdout_log = OpenOptions::new()
         .append(true)
         .open(data_dir.join("logs/server.out.log"))?;
     let stderr_log = OpenOptions::new()
         .append(true)
         .open(data_dir.join("logs/server.err.log"))?;
-    let server_path = server_dir.join("stack_export_prod/app-server/bin/python");
-    server_dir.pop();
+    let server_path = if cfg!(debug_assertions) {
+        server_dir.join("server/.venv/bin/python3")
+    } else {
+        server_dir.join("server/stack_export_prod/app-server/bin/python")
+    };
     let child = unsafe {
         Command::new(server_path)
             .args(["-m", "server.main"])

--- a/tiles/src/daemon/atproto.rs
+++ b/tiles/src/daemon/atproto.rs
@@ -28,6 +28,11 @@ pub struct AtLoginReq {
 }
 
 #[derive(Deserialize)]
+struct PublicProfile {
+    avatar: Option<String>,
+}
+
+#[derive(Deserialize)]
 pub struct ShareSessionReq {
     /// A private share is encrypted before it goes to the PDS, and the key
     /// rides in the link's fragment rather than in the record
@@ -134,15 +139,41 @@ pub async fn logout() -> Result<impl IntoResponse, AppError> {
 }
 
 pub async fn status() -> Result<impl IntoResponse, AppError> {
-    let user_db_conn = get_db_conn(&crate::core::storage::db::DBTYPE::COMMON)
-        .map_err(|e| AppError::CannotProcess(e.to_string()))?;
+    let atproto_user = {
+        let user_db_conn = get_db_conn(&crate::core::storage::db::DBTYPE::COMMON)
+            .map_err(|e| AppError::CannotProcess(e.to_string()))?;
 
-    if let Some(atproto_user) = atproto::fetch_logged_in_data(&user_db_conn)
-        .map_err(|e| AppError::CannotProcess(e.to_string()))?
-    {
+        atproto::fetch_logged_in_data(&user_db_conn)
+            .map_err(|e| AppError::CannotProcess(e.to_string()))?
+    };
+
+    if let Some(atproto_user) = atproto_user {
+        // Profile metadata is public and optional. An offline AppView must not
+        // make a valid local login look disconnected.
+        let avatar = match reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .build()
+        {
+            Ok(client) => match client
+                .get("https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile")
+                .query(&[("actor", atproto_user.key.as_str())])
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => response
+                    .json::<PublicProfile>()
+                    .await
+                    .ok()
+                    .and_then(|profile| profile.avatar),
+                _ => None,
+            },
+            Err(_) => None,
+        };
+
         Ok(ApiResponse::success(json!({
             "handle": atproto_user.handle,
-            "did": atproto_user.key
+            "did": atproto_user.key,
+            "avatar": avatar
         })))
     } else {
         Err(AppError::NotFound("Not logged-in".to_string()))

--- a/tiles/src/daemon/session.rs
+++ b/tiles/src/daemon/session.rs
@@ -236,6 +236,8 @@ mod tests {
                 "-c",
                 r#"read request
   printf '{"type": "response", "command": "new_session", "success": true, "data": {"cancelled": false}}\n'
+  # A delayed duplicate must not be mistaken for the following get_state reply.
+  printf '{"type": "response", "command": "new_session", "success": true, "data": {"cancelled": false}}\n'
     read request
  printf '{"type": "response", "command": "get_state", "success": true, "data": {"sessionId": "session_id", "model": {"id": "id", "name": "model"}, "thinkingLevel": "high", "isStreaming": true}}\n'
   "#,


### PR DESCRIPTION
This updates the menu bar app's power and account behavior and fixes Pi session response handling and the development server executable path.

- Allow Stay Awake on battery above 10%, stop sessions at the protected battery level, and show availability in the menu.
- Clarify Tiles and Atmosphere account copy and return optional public profile avatars without failing login status when the AppView is unavailable.
- Match Pi replies to the requested command so a delayed `new_session` reply cannot be consumed as `get_state`; extend the regression test.
- Use the server virtual environment's Python executable in debug builds while retaining the packaged executable in release builds.

Validation: 8 Stay Awake tests and 6 daemon session tests passed; Svelte check reported zero errors and warnings; `cargo fmt --all -- --check` and `git diff --check` passed. Native UI interactions and live profile retrieval were not manually tested.

AI assistance: Codex inspected the existing changes, removed local diagram artifacts, ran validation, and prepared this draft commit and PR. No application code was generated or modified during this preparation. Human review is required before merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791694590&installation_model_id=435623&pr_number=218&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F218&signature=ee05d11cb186f00bcf653c9d8da717f275061187a6eebe14b5a8df345e2d7542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->