### PR TITLE
Fix ATproto avatars in the packaged WebUI

### DIFF
--- a/tiles/src/daemon/atproto.rs
+++ b/tiles/src/daemon/atproto.rs
@@ -1,9 +1,10 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use axum::{
     Json, Router,
     extract::Path,
+    http::header::CONTENT_TYPE,
     response::IntoResponse,
     routing::{get, post},
 };
@@ -31,6 +32,12 @@ pub struct AtLoginReq {
 struct PublicProfile {
     avatar: Option<String>,
 }
+
+/// Keep the status response small enough to render safely inside the WebView.
+const AVATAR_MAX_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Formats supported by WebKit and the menubar avatar implementation.
+const AVATAR_TYPES: [&str; 4] = ["image/jpeg", "image/png", "image/webp", "image/gif"];
 
 #[derive(Deserialize)]
 pub struct ShareSessionReq {
@@ -138,6 +145,48 @@ pub async fn logout() -> Result<impl IntoResponse, AppError> {
     Ok(ApiResponse::success(json!(resp)))
 }
 
+fn encode_avatar(mime: &str, bytes: &[u8]) -> Option<String> {
+    if !AVATAR_TYPES.contains(&mime) || bytes.len() as u64 > AVATAR_MAX_BYTES {
+        return None;
+    }
+
+    Some(format!(
+        "data:{mime};base64,{}",
+        data_encoding::BASE64.encode(bytes)
+    ))
+}
+
+/// Tauri's WebView intentionally blocks remote image URLs. Download the public
+/// avatar in the daemon and return the same bounded data URI used by the
+/// menubar instead of widening the app's content security policy.
+async fn fetch_avatar(client: &reqwest::Client, url: &str) -> Option<String> {
+    if !url.starts_with("https://") {
+        return None;
+    }
+
+    let response = client.get(url).send().await.ok()?;
+    if !response.status().is_success()
+        || response
+            .content_length()
+            .is_some_and(|len| len > AVATAR_MAX_BYTES)
+    {
+        return None;
+    }
+
+    let mime = response
+        .headers()
+        .get(CONTENT_TYPE)?
+        .to_str()
+        .ok()?
+        .split(';')
+        .next()?
+        .trim()
+        .to_ascii_lowercase();
+    let bytes = response.bytes().await.ok()?;
+
+    encode_avatar(&mime, &bytes)
+}
+
 pub async fn status() -> Result<impl IntoResponse, AppError> {
     let atproto_user = {
         let user_db_conn = get_db_conn(&crate::core::storage::db::DBTYPE::COMMON)
@@ -151,22 +200,29 @@ pub async fn status() -> Result<impl IntoResponse, AppError> {
         // Profile metadata is public and optional. An offline AppView must not
         // make a valid local login look disconnected.
         let avatar = match reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(3))
+            .timeout(Duration::from_secs(3))
             .build()
         {
-            Ok(client) => match client
-                .get("https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile")
-                .query(&[("actor", atproto_user.key.as_str())])
-                .send()
-                .await
-            {
-                Ok(response) if response.status().is_success() => response
-                    .json::<PublicProfile>()
+            Ok(client) => {
+                let avatar_url = match client
+                    .get("https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile")
+                    .query(&[("actor", atproto_user.key.as_str())])
+                    .send()
                     .await
-                    .ok()
-                    .and_then(|profile| profile.avatar),
-                _ => None,
-            },
+                {
+                    Ok(response) if response.status().is_success() => response
+                        .json::<PublicProfile>()
+                        .await
+                        .ok()
+                        .and_then(|profile| profile.avatar),
+                    _ => None,
+                };
+
+                match avatar_url {
+                    Some(url) => fetch_avatar(&client, &url).await,
+                    None => None,
+                }
+            }
             Err(_) => None,
         };
 
@@ -177,5 +233,23 @@ pub async fn status() -> Result<impl IntoResponse, AppError> {
         })))
     } else {
         Err(AppError::NotFound("Not logged-in".to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_avatar;
+
+    #[test]
+    fn avatar_is_encoded_as_a_webview_safe_data_uri() {
+        assert_eq!(
+            encode_avatar("image/png", &[0, 1, 2]),
+            Some("data:image/png;base64,AAEC".to_owned())
+        );
+    }
+
+    #[test]
+    fn non_image_avatar_is_rejected() {
+        assert_eq!(encode_avatar("text/html", b"not an image"), None);
     }
 }


### PR DESCRIPTION
## Summary
- download the public ATproto avatar through the Tiles daemon
- validate HTTPS, supported image MIME types, and a 2 MB size limit
- return a data URI that satisfies the packaged Tauri WebView CSP
- preserve initials when profile or avatar retrieval fails

## Why
The packaged WebUI runs at tauri://localhost and intentionally blocks remote image URLs. The status endpoint previously returned a cdn.bsky.app URL, so the avatar could load in a browser but not inside Tauri. This follows the existing menubar approach without widening the CSP.

## Verification
- cargo fmt --check --package tiles
- cargo test -p tiles: 168 passed
- verified the live profile avatar is a supported 88 KB WebP response

## AI assistance disclosure
AI assistance was used to inspect the Tauri CSP and existing menubar implementation, draft the focused daemon change, and add its unit tests. The resulting code was reviewed against the existing pattern and validated with the full Tiles crate test suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tilesprivacy/codesmith/tiles/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791715521&installation_model_id=435623&pr_number=219&repository=tilesprivacy%2Ftiles&return_to=https%3A%2F%2Fgithub.com%2Ftilesprivacy%2Ftiles%2Fpull%2F219&signature=d47e90fad9ec2713f78122c1c3ca32dffbc4c12f3ca8e929f26a5c3b2e458655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->